### PR TITLE
Check if colorscheme is set to null

### DIFF
--- a/nixvim.nix
+++ b/nixvim.nix
@@ -204,7 +204,7 @@ in
       });
 
       configure = {
-        customRC = cfg.extraConfigVim + (optionalString (cfg.colorscheme != "") ''
+        customRC = cfg.extraConfigVim + (optionalString (cfg.colorscheme != "" && cfg.colorscheme != null) ''
           colorscheme ${cfg.colorscheme}
         '') + ''
           lua <<EOF


### PR DESCRIPTION
If colorscheme is not set nixvim will not work.
This is because the default is null.

In this PR I have just added an extra check to see if colorscheme is null.
However we might want to change the type of colorscheme itself to only support strings and set the defualt to `""`.

Edit:

Here is the error I am getting, for reference.

```
error: cannot coerce null to a string

       at /nix/store/95s39kpv3cg61qshwxd98lxvfr7hib4d-source/nixvim.nix:208:23:

          207|         customRC = cfg.extraConfigVim + (optionalString (cfg.colorscheme != "") ''
          208|           colorscheme ${cfg.colorscheme}
             |                       ^
          209|         '') + ''
(use '--show-trace' to show detailed location information)
```