### PR TITLE
added nord colorscheme

### DIFF
--- a/nixvim.nix
+++ b/nixvim.nix
@@ -204,13 +204,16 @@ in
       });
 
       configure = {
-        customRC = cfg.extraConfigVim + (optionalString (cfg.colorscheme != "" && cfg.colorscheme != null) ''
-          colorscheme ${cfg.colorscheme}
-        '') + ''
+        customRC = cfg.extraConfigVim + ''
           lua <<EOF
           ${cfg.extraConfigLua}
           EOF
-        '';
+        '' +
+        # Set colorscheme after setting globals.
+        # Some colorschemes depends on variables being set before setting the colorscheme.
+        (optionalString (cfg.colorscheme != "" && cfg.colorscheme != null) ''
+          colorscheme ${cfg.colorscheme}
+        '') ;
 
         packages.nixvim = {
           start = filter (f: f != null) (map

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -1,0 +1,49 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let 
+  cfg = config.programs.nixvim.colorschemes.nord;
+in
+{
+  options = {
+    programs.nixvim.colorschemes.nord = {
+      enable = mkEnableOption "Enable nord";
+
+      contrast = mkEnableOption
+        "Make sidebars and popup menus like nvim-tree and telescope have a different background";
+
+      borders = mkEnableOption
+        "Enable the border between verticaly split windows visable";
+
+      disable_background = mkEnableOption
+        "Disable the setting of background color so that NeoVim can use your terminal background";
+
+      cursorline_transparent = mkEnableOption
+        "Set the cursorline transparent/visible";
+
+      enable_sidebar_background = mkEnableOption
+        "Re-enables the background of the sidebar if you disabled the background of everything";
+
+      italic = mkOption {
+        description = "enables/disables italics";
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.nixvim = {
+      colorscheme = "nord";
+      extraPlugins = [ pkgs.vimPlugins.nord-nvim ];
+
+      globals = {
+        nord_contrast = mkIf cfg.contrast 1;
+        nord_borders = mkIf cfg.borders 1;
+        nord_disable_background = mkIf cfg.disable_background 1;
+        nord_cursoline_transparent = mkIf cfg.cursorline_transparent 1;
+        nord_enable_sidebar_background = mkIf cfg.enable_sidebar_background 1;
+        nord_italic = cfg.italic;
+      };
+    };
+  };
+}

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -25,8 +25,8 @@ in
 
       italic = mkOption {
         description = "enables/disables italics";
-        type = types.bool;
-        default = true;
+        type = types.nullOr types.bool;
+        default = null;
       };
     };
   };
@@ -42,7 +42,7 @@ in
         nord_disable_background = mkIf cfg.disable_background 1;
         nord_cursoline_transparent = mkIf cfg.cursorline_transparent 1;
         nord_enable_sidebar_background = mkIf cfg.enable_sidebar_background 1;
-        nord_italic = cfg.italic;
+        nord_italic = mkIf (cfg.italic != null) cfg.italic;
       };
     };
   };

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -5,6 +5,7 @@
 
     ./colorschemes/base16.nix
     ./colorschemes/gruvbox.nix
+    ./colorschemes/nord.nix
     ./colorschemes/one.nix
     ./colorschemes/onedark.nix
     ./colorschemes/tokyonight.nix


### PR DESCRIPTION
This PR adds the nord colorscheme as a module with the [`nord-nvim`](https://github.com/shaunsingh/nord.nvim) package 