### PR TITLE
nvim-tree: git.enable expects a boolean

### DIFF
--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -116,7 +116,7 @@ in
 
     git = {
       enable = mkOption {
-        type = types.nullOr types.str;
+        type = types.nullOr types.bool;
         default = null;
         description = "Enable git integration";
       };


### PR DESCRIPTION
Currently the options `plugins.nvim-tree.git.enable` expects null or a string.
However, this is not correct and results in an error when starting neovim, when nvim-tree is enabled.

This PR changes the option to expect a boolean.