### PR TITLE
Adding nvim-cmp plugin

### DIFF
--- a/plugins/completion/nvim-cmp/cmp-helpers.nix
+++ b/plugins/completion/nvim-cmp/cmp-helpers.nix
@@ -1,0 +1,54 @@
+{ lib, pkgs, ... }@attrs:
+let
+  helpers = import ../../helpers.nix { lib = lib; };
+in with helpers; with lib;
+{
+  mkCmpSourcePlugin = { name, extraPlugins ? [], useDefaultPackage ? true, ... }: mkPlugin attrs {
+    inherit name;
+    extraPlugins = extraPlugins ++ (lists.optional useDefaultPackage pkgs.vimPlugins.${name});
+    description = "Enable ${name}";
+  };
+
+  pluginAndSourceNames = {
+    "luasnip" = "cmp_luasnip";
+    "snippy" = "cmp-snippy";
+    "ultisnips" = "cmp-nvim-ultisnips";
+    "vsnip" = "cmp-vsnip";
+    "buffer" = "cmp-buffer";
+    "calc" = "cmp-calc";
+    "dictionary" = "cmp-dictionary";
+    "digraphs" = "cmp-digraphs";
+    "omni" = "cmp-omni";
+    "spell" = "cmp-spell";
+    "nvim_lsp" = "cmp-nvim-lsp";
+    "nvim_lsp_document_symbol" = "cmp-nvim-lsp-document-symbol";
+    "nvim_lsp_signature_help" = "cmp-nvim-lsp-signature-help";
+    "vim_lsp" = "cmp-vim-lsp";
+    "path" = "cmp-path";
+    "git" = "cmp-git";
+    "conventionalcommits" = "cmp-conventionalcommits";
+    "cmdline" = "cmp-cmdline";
+    "cmp-cmdline-history" = "cmp-cmdline-history";
+    "fuzzy_buffer" = "cmp-fuzzy-buffer";
+    "fuzzy_path" = "cmp-fuzzy-path";
+    "rg" = "cmp-rg";
+    "fish" = "cmp-fish";
+    "tmux" = "cmp-tmux";
+    "zsh" = "cmp-zsh";
+    "crates" = "crates-nvim";
+    "npm" = "cmp-npm";
+    "cmp-clippy" = "cmp-clippy";
+    "cmp_tabnine" = "cmp-tabnine";
+    "copilot" = "cmp-copilot";
+    "dap" = "cmp-dap";
+    "emoji" = "cmp-emoji";
+    "greek" = "cmp-greek";
+    "latex_symbols" = "cmp-latex-symbols";
+    "look" = "cmp-look";
+    "nvim_lua" = "cmp-nvim-lua";
+    "pandoc_references" = "cmp-pandoc-references";
+    "cmp_pandoc" = "cmp-pandoc-nvim";
+    "treesitter" = "cmp-treesitter";
+    "vimwiki-tags" = "cmp-vimwiki-tags";
+  };
+}

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -101,6 +101,35 @@ in
         }
       '';
     };
+
+    completion = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          keyword_length = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+
+          keyword_pattern = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+          };
+
+          autocomplete = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            description = "Lua code for the event.";
+            example = ''"false"'';
+          };
+
+          completeopt = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -119,7 +148,12 @@ in
       snippet = {
         expand = if (isNull cfg.snippet.expand) then null else helpers.mkRaw cfg.snippet.expand;
       };
-      # completion = cfg.completion;
+      completion = if (isNull cfg.completion) then null else {
+        keyword_length = cfg.completion.keyword_length;
+        keyword_pattern = cfg.completion.keyword_pattern;
+        autocomplete = if (isNull cfg.completion.autocomplete) then null else mkRaw cfg.completion.autocomplete;
+        completeopt = cfg.completion.completeopt;
+      };
       # confirmation = cfg.confirmation;
       # formatting = cfg.formatting;
       # matching = cfg.matching;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -161,6 +161,26 @@ in
         };
       }));
     };
+
+    matching = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          disallow_fuzzy_matching = mkOption {
+            default = null;
+            type = types.nullOr types.bool;
+          };
+          disallow_partial_matching = mkOption {
+            default = null;
+            type = types.nullOr types.bool;
+          };
+          disallow_prefix_unmatching = mkOption {
+            default = null;
+            type = types.nullOr types.bool;
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -194,7 +214,7 @@ in
         fields = cfg.formatting.fields;
         format = if (isNull cfg.formatting.format) then null else helpers.mkRaw cfg.formatting.format;
       };
-      # matching = cfg.matching;
+      matching = cfg.matching;
       # sorting = cfg.sorting;
       # sources = cfg.sources;
       # view = cfg.view;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -197,6 +197,70 @@ in
         };
       }));
     };
+
+    sources = let
+      source_config = types.submodule ({...}: {
+        options = {
+          name = mkOption {
+            type = types.str;
+            description = "The name of the source.";
+            example = ''"buffer"'';
+          };
+
+          option = mkOption {
+            default = null;
+            type = with types; nullOr (attrsOf anything);
+            description = "If direct lua code is needed use helpers.mkRaw";
+          };
+
+          keyword_length = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+
+          keyword_pattern = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+
+          trigger_characters = mkOption {
+            default = null;
+            type = with types; nullOr (listOf str);
+          };
+
+          priority = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+
+          max_item_count = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+
+          group_index = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+        };
+      });
+    in mkOption {
+      default = null;
+      type = with types; nullOr (either (listOf source_config) (listOf (listOf source_config)));
+      description = ''
+        The sources to use.
+        Can either be a list of sourceConfigs which will be made directly to a Lua object.
+        Or it can be a list of lists, which will use the cmp built-in helper function `cmp.config.sources`.
+      '';
+      example = ''
+        [
+          { name = "nvim_lsp"; }
+          { name = "luasnip"; } #For luasnip users.
+          { name = "path"; }
+          { name = "buffer"; }
+        ]
+      '';
+    };
   };
 
   config = let
@@ -235,7 +299,7 @@ in
         priority_weight = cfg.sorting.priority_weight;
         comparators = if (isNull cfg.sorting.comparators) then null else helpers.mkRaw cfg.sorting.comparators;
       };
-      # sources = cfg.sources;
+      sources = cfg.sources;
       # view = cfg.view;
       # window = cfg.window;
       # experimental = cfg.experimental;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -143,6 +143,24 @@ in
         };
       }));
     };
+
+    formatting = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          fields = mkOption {
+            default = null;
+            type = types.nullOr (types.listOf types.str);
+            example = ''[ "kind" "abbr" "menu" ]'';
+          };
+          format = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            description = "A lua function as a string";
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -172,7 +190,10 @@ in
           if (isString cfg.confirmation.get_commit_characters) then helpers.mkRaw cfg.confirmation.get_commit_characters
           else cfg.confirmation.get_commit_characters;
       };
-      # formatting = cfg.formatting;
+      formatting = if (isNull cfg.formatting) then null else {
+        fields = cfg.formatting.fields;
+        format = if (isNull cfg.formatting.format) then null else helpers.mkRaw cfg.formatting.format;
+      };
       # matching = cfg.matching;
       # sorting = cfg.sorting;
       # sources = cfg.sources;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -3,6 +3,7 @@ with lib;
 let
   cfg = config.programs.nixvim.plugins.nvim-cmp;
   helpers = import ../../helpers.nix { lib = lib; };
+  cmpLib = import ./cmp-helpers.nix;
 in
 {
   options.programs.nixvim.plugins.nvim-cmp = {
@@ -198,6 +199,13 @@ in
       }));
     };
 
+    auto_enable_sources = mkOption {
+      default = true;
+      description = ''
+        Scans the sources array and installs the plugins if they are known to nixvim.
+      '';
+    };
+
     sources = let
       source_config = types.submodule ({...}: {
         options = {
@@ -312,6 +320,20 @@ in
         local cmp = require('cmp')
         cmp.setup(${helpers.toLuaObject options})
       '';
+
+      # If auto_enable_sources is set to true, figure out which are provided by the user
+      # and enable the corresponding plugins.
+      # plugins = let
+      #   flattened_sources = if (isNull cfg.sources) then [] else flatten cfg.sources;
+      #   found_sources = lists.unique (lists.map (source: source.name) flattened_sources);
+      #   known_source_names = attrNames cmpLib.pluginAndSourceNames;
+      #   # Check if source exists
+      #   known_sources = filter (source_name: elem source_name known_source_names) found_sources;
+      #   plugins_to_enable = map (source_name: cmpLib.pluginAndSourceNames.${source_name}) known_sources;
+      #   # Create attribute set with enabled plugins
+      #   attrs_enabled = listToAttrs (map (name: { inherit name; value.enable = true; }) plugins_to_enable);
+      #   # FIXME: Infinite recursion encountered
+      # in mkIf cfg.auto_enable_sources attrs_enabled;
     };
   };
 }

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -314,6 +314,9 @@ in
         };
       }));
     };
+
+    # This can be kept as types.attrs since experimental features are often removed or completely changed after a while
+    experimental = mkNullOrOption types.attrs "Experimental features";
   };
 
   config = let
@@ -355,7 +358,7 @@ in
       sources = cfg.sources;
       view = cfg.view;
       window = cfg.window;
-      # experimental = cfg.experimental;
+      experimental = cfg.experimental;
     };
   in mkIf cfg.enable {
     programs.nixvim = {

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -29,15 +29,36 @@ in
       default = null;
       example = ''"Item"'';
     };
+
+    snippet = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          expand = mkOption {
+            type = types.nullOr types.str;
+            example = ''
+              function(args)
+                vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
+                -- require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
+                -- require('snippy').expand_snippet(args.body) -- For `snippy` users.
+                -- vim.fn["UltiSnips#Anon"](args.body) -- For `ultisnips` users.
+              end
+            '';
+          };
+        };
+      }));
+    };
   };
 
   config = let
     options = {
       enabled = cfg.enable;
       performance = cfg.performance;
-      preselect = if (isNull cfg.preselect) then null else { __raw = "cmp.PreselectMode.${cfg.preselect}"; };
+      preselect = if (isNull cfg.preselect) then null else helpers.mkRaw "cmp.PreselectMode.${cfg.preselect}";
       # mapping = cfg.mapping;
-      # snippet = cfg.snippet;
+      snippet = {
+        expand = if (isNull cfg.snippet.expand) then null else helpers.mkRaw cfg.snippet.expand;
+      };
       # completion = cfg.completion;
       # confirmation = cfg.confirmation;
       # formatting = cfg.formatting;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -181,6 +181,22 @@ in
         };
       }));
     };
+
+    sorting = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          priority_weight = mkOption {
+            default = null;
+            type = types.nullOr types.int;
+          };
+          comparators = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -215,7 +231,10 @@ in
         format = if (isNull cfg.formatting.format) then null else helpers.mkRaw cfg.formatting.format;
       };
       matching = cfg.matching;
-      # sorting = cfg.sorting;
+      sorting = if (isNull cfg.sorting) then null else {
+        priority_weight = cfg.sorting.priority_weight;
+        comparators = if (isNull cfg.sorting.comparators) then null else helpers.mkRaw cfg.sorting.comparators;
+      };
       # sources = cfg.sources;
       # view = cfg.view;
       # window = cfg.window;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -3,6 +3,7 @@ with lib;
 let
   cfg = config.programs.nixvim.plugins.nvim-cmp;
   helpers = import ../../helpers.nix { lib = lib; };
+  mkNullOrOption = helpers.mkNullOrOption;
   cmpLib = import ./cmp-helpers.nix args;
 in
 {
@@ -281,6 +282,38 @@ in
         };
       }));
     };
+
+    window = let
+      # Reusable options
+      border = with types; mkNullOrOption (either str (listOf str)) null;
+      winhighlight = mkNullOrOption types.str null;
+      zindex = mkNullOrOption types.int null;
+    in mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          completion = mkOption {
+            default = null;
+            type = types.nullOr (types.submodule ({...}: {
+              options = {
+                inherit border winhighlight zindex;
+              };
+            }));
+          };
+
+          documentation = mkOption {
+            default = null;
+            type = types.nullOr (types.submodule ({...}: {
+              options = {
+                inherit border winhighlight zindex;
+                max_width = mkNullOrOption types.int "Window's max width";
+                max_height = mkNullOrOption types.int "Window's max height";
+              };
+            }));
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -321,7 +354,7 @@ in
       };
       sources = cfg.sources;
       view = cfg.view;
-      # window = cfg.window;
+      window = cfg.window;
       # experimental = cfg.experimental;
     };
   in mkIf cfg.enable {

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -269,6 +269,18 @@ in
         ]
       '';
     };
+
+    view = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          entries = mkOption {
+            default = null;
+            type = with types; nullOr (either str attrs);
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -308,7 +320,7 @@ in
         comparators = if (isNull cfg.sorting.comparators) then null else helpers.mkRaw cfg.sorting.comparators;
       };
       sources = cfg.sources;
-      # view = cfg.view;
+      view = cfg.view;
       # window = cfg.window;
       # experimental = cfg.experimental;
     };

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -1,0 +1,61 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let
+  cfg = config.programs.nixvim.plugins.nvim-cmp;
+  helpers = import ../../helpers.nix { lib = lib; };
+in
+{
+  options.programs.nixvim.plugins.nvim-cmp = {
+    enable = mkEnableOption "Enable nvim-cmp";
+
+    performance = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          debounce = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+          };
+          throttle = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+          };
+        };
+      }));
+    };
+
+    preselect = mkOption {
+      type = types.nullOr (types.enum [ "Item" "None" ]);
+      default = null;
+      example = ''"Item"'';
+    };
+  };
+
+  config = let
+    options = {
+      enabled = cfg.enable;
+      performance = cfg.performance;
+      preselect = if (isNull cfg.preselect) then null else { __raw = "cmp.PreselectMode.${cfg.preselect}"; };
+      # mapping = cfg.mapping;
+      # snippet = cfg.snippet;
+      # completion = cfg.completion;
+      # confirmation = cfg.confirmation;
+      # formatting = cfg.formatting;
+      # matching = cfg.matching;
+      # sorting = cfg.sorting;
+      # sources = cfg.sources;
+      # view = cfg.view;
+      # window = cfg.window;
+      # experimental = cfg.experimental;
+    };
+  in mkIf cfg.enable {
+    programs.nixvim = {
+      extraPlugins = [ pkgs.vimPlugins.nvim-cmp ];
+
+      extraConfigLua = ''
+        local cmp = require('cmp')
+        cmp.setup(${helpers.toLuaObject options})
+      '';
+    };
+  };
+}

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -130,6 +130,19 @@ in
         };
       }));
     };
+
+    confirmation = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule ({...}: {
+        options = {
+          get_commit_characters = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            description = "Direct lua code as a string";
+          };
+        };
+      }));
+    };
   };
 
   config = let
@@ -154,7 +167,11 @@ in
         autocomplete = if (isNull cfg.completion.autocomplete) then null else mkRaw cfg.completion.autocomplete;
         completeopt = cfg.completion.completeopt;
       };
-      # confirmation = cfg.confirmation;
+      confirmation = if (isNull cfg.confirmation) then null else {
+        get_commit_characters =
+          if (isString cfg.confirmation.get_commit_characters) then helpers.mkRaw cfg.confirmation.get_commit_characters
+          else cfg.confirmation.get_commit_characters;
+      };
       # formatting = cfg.formatting;
       # matching = cfg.matching;
       # sorting = cfg.sorting;

--- a/plugins/completion/nvim-cmp/sources/default.nix
+++ b/plugins/completion/nvim-cmp/sources/default.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, ... }@attrs:
+with lib;
+let
+  cmpLib = import ../cmp-helpers.nix attrs;
+  cmpSourcesPluginNames = lib.attrValues cmpLib.pluginAndSourceNames;
+  pluginModules = lists.map (name: cmpLib.mkCmpSourcePlugin { inherit name; }) cmpSourcesPluginNames;
+in
+{
+  # For extra cmp plugins
+  imports = [
+  ] ++ pluginModules;
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -12,6 +12,7 @@
 
     ./completion/coq.nix
     ./completion/nvim-cmp
+    ./completion/nvim-cmp/sources
 
     ./git/fugitive.nix
     ./git/gitgutter.nix

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -11,6 +11,7 @@
     ./colorschemes/tokyonight.nix
 
     ./completion/coq.nix
+    ./completion/nvim-cmp
 
     ./git/fugitive.nix
     ./git/gitgutter.nix


### PR DESCRIPTION
This pull request is a draft just to share my initial work on this.

As a user of nvim-cmp, I think it would be nice to have cmp as a module which this pull request aims to add.

If you have any inputs to this or any suggestions on how to improve it, please add a comment.

I will probably finish this over the next couple of days.

Config options completed:
- [x] enabled
- [x] performance
- [x] preselect
- [x] mapping
- [x] snippet
- [x] completion
- [x] confirmation
- [x] formatting
- [x] matching
- [x] sorting
- [x] sources
- [x] view
- [x] window
- [x] experimental