### PR TITLE
telescope.media_files: init

### DIFF
--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -9,6 +9,7 @@ in
     ./frecency.nix
     ./fzf-native.nix
     ./fzy-native.nix
+    ./media-files.nix
   ];
 
   # TODO:add support for aditional filetypes. This requires autocommands!

--- a/plugins/telescope/media-files.nix
+++ b/plugins/telescope/media-files.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let 
+  cfg = config.programs.nixvim.plugins.telescope.extensions.media_files;
+in
+{
+  options.programs.nixvim.plugins.telescope.extensions.media_files = {
+    enable = mkEnableOption "Enable media_files extension for telescope";
+
+    filetypes = mkOption {
+      default = types.null;
+      type = with types; nullOr (listOf str);
+    };
+
+    find_cmd = mkOption {
+      default = null;
+      type = with types; nollOr str;
+      example = ''"rg"'';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.nixvim = {
+      plugins.telescope.enabledExtensions = [ "media_files" ];
+
+      extraPlugins = with pkgs.vimPlugins; [
+        popup-nvim
+        plenary-nvim
+        telescope-media-files-nvim
+      ];
+
+      extraPackages = with pkgs; [
+        ueberzug
+      ];
+    };
+
+  };
+}

--- a/plugins/telescope/media-files.nix
+++ b/plugins/telescope/media-files.nix
@@ -14,7 +14,7 @@ in
 
     find_cmd = mkOption {
       default = null;
-      type = with types; nollOr str;
+      type = with types; nullOr str;
       example = ''"rg"'';
     };
   };


### PR DESCRIPTION
Just sharing my initial work on telescope media_files extension.
The only problem with this is that the plugin does not exist in nixpkgs yes, so we can either wait for that or depend on https://github.com/m15a/nixpkgs-vim-extra-plugins
But I am marking it as draft until it is added in nixpkgs or we decide to depend on vim-extra-plugins.

A word of appreciation:
A nice thing about nixvim is that we can directly add dependencies such as `überzug` which makes it much easier for the user to configure and not have to manually add it to their list of packages.

Issue in nixpkgs:
NixOS/nixpkgs#182734