### PR TITLE
null-ls: init with prettier and flake8

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -23,6 +23,8 @@
     ./languages/treesitter.nix
     ./languages/zig.nix
 
+    ./null-ls
+
     ./nvim-lsp
     ./nvim-lsp/lspsaga.nix
 

--- a/plugins/null-ls/default.nix
+++ b/plugins/null-ls/default.nix
@@ -1,0 +1,47 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  cfg = config.programs.nixvim.plugins.null-ls;
+  helpers = (import ../helpers.nix { inherit lib; });
+in
+{
+  imports = [
+    ./servers.nix
+  ];
+
+  options.programs.nixvim.plugins.null-ls = {
+    enable = mkEnableOption "Enable null-ls";
+
+    debug = mkOption {
+      default = null;
+      type = with types; nullOr bool;
+    };
+
+    sourcesItems = mkOption {
+      default = null;
+      # type = with types; nullOr (either (listOf str) (listOf attrsOf str));
+      type = with types; nullOr (listOf (attrsOf str));
+      description = "The list of sources to enable, should be strings of lua code. Don't use this directly";
+    };
+
+    # sources = mkOption {
+    #   default = null;
+    #   type = with types; nullOr attrs;
+    # };
+  };
+
+  config = let
+    options = {
+      debug = cfg.debug;
+      sources = cfg.sourcesItems;
+    };
+  in mkIf cfg.enable {
+    programs.nixvim = {
+      extraPlugins = with pkgs.vimPlugins; [ null-ls-nvim ];
+
+      extraConfigLua = ''
+        require("null-ls").setup(${helpers.toLuaObject options})
+      '';
+    };
+  };
+}

--- a/plugins/null-ls/helpers.nix
+++ b/plugins/null-ls/helpers.nix
@@ -1,0 +1,46 @@
+{ pkgs, config, lib, ... }:
+
+{
+  mkServer = {
+    name,
+    sourceType,
+    description ? "Enable ${name} source, for null-ls.",
+    packages ? [],
+    ... }: 
+      # returns a module
+      { pkgs, config, lib, ... }@args:
+        with lib;
+        let
+          helpers = import ../helpers.nix args;
+          cfg = config.programs.nixvim.plugins.null-ls.sources.${sourceType}.${name};
+        in
+        {
+          options.programs.nixvim.plugins.null-ls.sources.${sourceType}.${name} = {
+            enable = mkEnableOption description;
+
+            # TODO: withArgs can exist outside of the module in a generalized manner
+            withArgs = mkOption {
+              default = null;
+              type = with types; nullOr str;
+              description = ''Raw Lua code to be called with the with function'';
+              # Not sure that it makes sense to have the same example for all servers
+              # example = ''
+              #   '\'{ extra_args = { "--no-semi", "--single-quote", "--jsx-single-quote" } }'\'
+              # '';
+            };
+          };
+
+          config = mkIf cfg.enable {
+            programs.nixvim = {
+              extraPackages = packages;
+
+              # Add source to list of sources
+              plugins.null-ls.sourcesItems = let
+                sourceItem = "${sourceType}.${name}";
+                withArgs = if (isNull cfg.withArgs) then sourceItem else "${sourceItem}.with ${cfg.withArgs}";
+                finalString = ''require("null-ls").builtins.${withArgs}'';
+              in [ (helpers.mkRaw finalString) ];
+            };
+          };
+        };
+}

--- a/plugins/null-ls/servers.nix
+++ b/plugins/null-ls/servers.nix
@@ -1,0 +1,33 @@
+{ pkgs, config, lib, ... }@args:
+let
+  helpers = import ./helpers.nix args;
+  serverData = {
+    code_actions = {
+    };
+    completion = {
+    };
+    diagnostics = {
+    };
+    formatting = {
+      prettier = {
+        packages = [ pkgs.nodePackages.prettier ];
+      };
+      flake8 = {
+        packages = [ pkgs.python3Packages.flake8 ];
+      };
+    };
+  };
+  # Format the servers to be an array of attrs like the following example
+  # [{
+  #   name = "prettier";
+  #   sourceType = "formatting";
+  #   packages = [...];
+  # }]
+  serverDataFormatted = lib.mapAttrsToList (sourceType: sourceSet:
+    lib.mapAttrsToList (name: attrs: attrs // { inherit sourceType name; }) sourceSet
+  ) serverData;
+  dataFlattened = lib.flatten serverDataFormatted;
+in
+{
+  imports = lib.lists.map (helpers.mkServer) dataFlattened;
+}


### PR DESCRIPTION
This PR adds the base work null-ls to work with nixvim.
I have made it easy to add new servers, so we can make new PRs for those.

Any improvements or suggestions are welcome.