### PR TITLE
null-ls: added alejandro and nixfmt

### DIFF
--- a/plugins/null-ls/servers.nix
+++ b/plugins/null-ls/servers.nix
@@ -9,6 +9,12 @@ let
     diagnostics = {
     };
     formatting = {
+      alejandra = {
+        packages = [ pkgs.alejandra ];
+      };
+      nixfmt = {
+        packages = [ pkgs.nixfmt ];
+      };
       prettier = {
         packages = [ pkgs.nodePackages.prettier ];
       };


### PR DESCRIPTION
This PR adds two new formatting servers to null-ls