### PR TITLE
lualine: fix components config

### DIFF
--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -20,27 +20,36 @@ let
     });
     default = null;
   };
-  component_options = mode:
+  component_options = defaultName:
     mkOption {
-      type = types.nullOr (types.submodule {
-        options = {
-          mode = mkOption {
-            type = types.str;
-            default = "${mode}";
+      type = types.nullOr (types.listOf (types.oneOf [
+        types.str
+        (types.submodule {
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = "component name";
+              default = defaultName;
+            };
+            icons_enabled = mkOption {
+              type = types.enum [ "True" "False" ];
+              default = "True";
+              description = "displays icons in alongside component";
+            };
+            icon = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "displays icon in front of the component";
+            };
+            separator = separators;
+            extraConfig = mkOption {
+              type = types.attrs;
+              default = { };
+              description = "extra options for the component";
+            };
           };
-          icons_enabled = mkOption {
-            type = types.enum [ "True" "False" ];
-            default = "True";
-            description = "displays icons in alongside component";
-          };
-          icon = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "displays icon in front of the component";
-          };
-          separator = separators;
-        };
-      });
+        })
+      ]));
       default = null;
     };
 in
@@ -112,6 +121,14 @@ in
   };
   config =
     let
+      processComponent = x: (if isAttrs x then processTableComponent else id) x;
+      processTableComponent = { name, icons_enabled, icon, separator, extraConfig }: mergeAttrs
+        {
+          "@" = name;
+          inherit icons_enabled icon separator;
+        }
+        extraConfig;
+      processSections = sections: mapAttrs (_: mapNullable (map processComponent)) sections;
       setupOptions = {
         options = {
           theme = cfg.theme;
@@ -121,8 +138,8 @@ in
           always_divide_middle = cfg.alwaysDivideMiddle;
         };
 
-        sections = cfg.sections;
-        tabline = cfg.tabline;
+        sections = mapNullable processSections cfg.sections;
+        tabline = mapNullable processSections cfg.tabline;
         extensions = cfg.extensions;
       };
     in


### PR DESCRIPTION
The original implementation has several flaws:
- Each section may have only one component. However, lualine supports multiple components in the same section. E.g. `lualine_b = {'branch', 'diff', 'diagnostics'},` in default settings.
- The output format is incorrect. It outputs `{ mode = 'filename', icons = ... }` while lualine expects something like `{ 'filename', file_status = true, ... }`.
- There are many extra settings lualine accepts other than the ones specified in the spec. Adding them to the nixvim managed config results in a type error.

The new implementation changes the accepted section type from `submodule` to `listOf (oneOf str submodule)`, generates the correct output, and adds a new `extraConfig` field for unknown upstream flags.