### PR TITLE
Add new plugin: copilot

### DIFF
--- a/plugins/completion/copilot.nix
+++ b/plugins/completion/copilot.nix
@@ -1,0 +1,36 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  cfg = config.plugins.copilot;
+in
+{
+  options = {
+    plugins.copilot = {
+      enable = mkEnableOption "Enable copilot";
+      filetypes = mkOption {
+        type = types.attrsOf types.bool;
+        description = "A dictionary mapping file types to their enabled status";
+        default = { };
+        example = literalExpression ''{
+          "*": false,
+          python: true
+        }'';
+      };
+      proxy = mkOption {
+        type = types.nullOr types.str;
+        description = "Tell Copilot what proxy server to use.";
+        default = null;
+        example = "localhost:3128";
+      };
+    };
+  };
+
+  config =
+    mkIf cfg.enable {
+      extraPlugins = [ pkgs.vimPlugins.copilot-vim ];
+      globals = {
+        copilot_node_command = "${pkgs.nodejs-16_x}/bin/node";
+        copilot_filetypes = cfg.filetypes;
+      } // (if cfg.proxy != null then { copilot_proxy = cfg.proxy; } else { });
+    };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -11,6 +11,7 @@
     ./colorschemes/tokyonight.nix
 
     ./completion/coq.nix
+    ./completion/copilot.nix
     ./completion/nvim-cmp
     ./completion/nvim-cmp/sources
 


### PR DESCRIPTION
Copilot-vim needs node 16.x or 17.x to work.