### PR TITLE
New wrapDo helper and wrapping nvim-cmp in do ... end

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -394,7 +394,7 @@ in
     mkIf cfg.enable {
       extraPlugins = [ pkgs.vimPlugins.nvim-cmp ];
 
-      extraConfigLua = ''
+      extraConfigLua = helpers.wrapDo ''
         local cmp = require('cmp')
         cmp.setup(${helpers.toLuaObject options})
       '';

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -105,4 +105,10 @@ rec {
   };
 
   mkRaw = r: { __raw = r; };
+
+  wrapDo = string: ''
+  do
+    ${string}
+  end
+  '';
 }


### PR DESCRIPTION
My original goal was to try and fix the cmp issue in #52, but it did not help.

This pull request adds a helper function that will wrap a string (or more preferably lua code) in a `do ... end`.
It also uses this helper in nvim-cmp.