### PR TITLE
nvim-tree: added new option

### DIFF
--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -48,7 +48,13 @@ in
       description = "Hijack cursor";
     };
 
+    # TODO: change this to it's new definition sync_root_with_cwd
     updateCwd = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+    };
+
+    respectBufCwd = mkOption {
       type = types.nullOr types.bool;
       default = null;
     };
@@ -94,6 +100,7 @@ in
         default = null;
       };
 
+      # TODO: change this to it's new definition update_root
       updateCwd = mkOption {
         type = types.nullOr types.bool;
         default = null;
@@ -214,6 +221,7 @@ in
         open_on_tab = cfg.openOnTab;
         hijack_cursor = cfg.hijackCursor;
         update_cwd = cfg.updateCwd;
+        respect_buf_cwd = cfg.respectBufCwd;
         update_to_buf_dir = {
           enable = cfg.updateToBufDir.enable;
           auto_open = cfg.updateToBufDir.autoOpen;


### PR DESCRIPTION
Adds new option to nvim-tree.

Also I am not sure what to do with old options. updateCwd should be changed to sync_root_with_cwd, but I don't think we should remove the old option, since it would break some configs.