### PR TITLE
luasnip: init plugin

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -32,6 +32,8 @@
 
     ./pluginmanagers/packer.nix
 
+    ./snippets/luasnip
+
     ./statuslines/airline.nix
     ./statuslines/lightline.nix
     ./statuslines/lualine.nix

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -23,6 +23,8 @@ rec {
     else if builtins.isString args then
       # This should be enough!
       escapeShellArg args
+    else if builtins.isPath args then
+      escapeShellArg args
     else if builtins.isBool args then
       "${ boolToString args }"
     else if builtins.isFloat args then

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -8,6 +8,11 @@ in
   options.plugins.luasnip = {
     enable = mkEnableOption "Enable luasnip";
 
+    package = mkOption {
+      default = pkgs.vimPlugins.luasnip;
+      type = types.package;
+    };
+
     fromVscode = mkOption {
       default = [ ];
       example = ''
@@ -87,7 +92,7 @@ in
         cfg.fromVscode;
     in
     mkIf cfg.enable {
-      extraPlugins = [ pkgs.vimPlugins.luasnip ];
+      extraPlugins = [ cfg.package ];
       extraConfigLua = concatStringsSep "\n" fromVscodeLoaders;
     };
 }

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -10,6 +10,19 @@ in
 
     fromVscode = mkOption {
       default = [ ];
+      example = ''
+        [
+          {}
+          {
+            paths = ./path/to/snippets;
+          }
+        ]
+        # generates:
+        # 
+        # require("luasnip.loaders.from_vscode").lazy_load({})
+        # require("luasnip.loaders.from_vscode").lazy_load({['paths'] = {'/nix/store/.../path/to/snippets'}})
+        #
+      '';
       type = types.listOf (types.submodule {
         options = {
           lazyLoad = mkOption {

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -1,0 +1,80 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let
+  cfg = config.plugins.luasnip;
+  helpers = import ../../helpers.nix { lib = lib; };
+in
+{
+  options.plugins.luasnip = {
+    enable = mkEnableOption "Enable luasnip";
+
+    loadVsCode = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether or not to lazy load vscode-like snippets
+      '';
+    };
+
+    fromVscode = mkOption {
+      default = null;
+      type = types.nullOr (types.submodule {
+        options = {
+          enable = mkEnableOption "Enable the vscode snippets loader for luasnip";
+          lazyLoad = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether or not to lazy load the snippets
+            '';
+          };
+
+          # TODO: add option to also include the default runtimepath
+          paths = mkOption {
+            default = null;
+            type = with types; nullOr (either str (listOf (either str path)));
+          };
+
+          exclude = mkOption {
+            type = types.nullOr (types.listOf types.str);
+            default = null;
+            description = ''
+              List of languages to exclude, by default is empty.
+            '';
+          };
+
+          include = mkOption {
+            type = types.nullOr (types.listOf types.str);
+            default = null;
+            description = ''
+              List of languages to include, by default is not set.
+            '';
+          };
+        };
+      });
+    };
+
+    # TODO: add support for snipmate
+    # TODO: add support for lua
+  };
+
+  config =
+    let
+      fromVscodeOptions =
+        if (isAttrs cfg.fromVscode) then
+          {
+            exclude = cfg.fromVscode.exclude;
+            include = cfg.fromVscode.include;
+            paths = cfg.fromVscode.paths;
+          }
+        else
+          { };
+    in
+    mkIf cfg.enable {
+      extraPlugins = [ pkgs.vimPlugins.luasnip ];
+
+      extraConfigLua = optionalString (isAttrs cfg.fromVscode && cfg.fromVscode.enable) ''
+        require("luasnip.loaders.from_vscode").${optionalString cfg.fromVscode.lazyLoad "lazy_"}load(${helpers.toLuaObject fromVscodeOptions})
+      '';
+    };
+}

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -32,7 +32,18 @@ in
           # TODO: add option to also include the default runtimepath
           paths = mkOption {
             default = null;
-            type = with types; nullOr (either str (listOf (either str path)));
+            type = with types; nullOr (oneOf
+              [
+                str
+                path
+                helpers.rawType
+                (listOf (oneOf
+                  [
+                    str
+                    path
+                    helpers.rawType
+                  ]))
+              ]);
           };
 
           exclude = mkOption {


### PR DESCRIPTION
Also added support for paths in `toLuaObject`.

I am not sure how to know what the path of the runtime dir is, but if it is possible I think we should add an option that can include the path of the runtime dir in the paths array.

nonetheless, the plugin module works in my tests.