### PR TITLE
helpers: expose to config.nixvim.helpers (take two)

### DIFF
--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -2,18 +2,28 @@ modules:
 { pkgs, config, lib, ... }:
 
 let
-  inherit (lib) mkEnableOption mkOption mkIf mkMerge types;
+  inherit (lib) mkEnableOption mkOption mkOptionType mkMerge mkIf types;
   cfg = config.programs.nixvim;
-in {
+in
+{
   options = {
-    programs.nixvim = lib.mkOption {
+    programs.nixvim = mkOption {
       type = types.submodule ((modules pkgs) ++ [{
         options.enable = mkEnableOption "nixvim";
       }]);
     };
+    nixvim.helpers = mkOption {
+      type = mkOptionType {
+        name = "helpers";
+        description = "Helpers that can be used when writing nixvim configs";
+        check = builtins.isAttrs;
+      };
+      description = "Use this option to access the helpers";
+      default = import ../plugins/helpers.nix { inherit (pkgs) lib; };
+    };
   };
 
-  config = mkIf cfg.enable 
+  config = mkIf cfg.enable
     (mkMerge [
       { home.packages = [ cfg.finalPackage ]; }
       (mkIf (!cfg.wrapRc) {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -2,18 +2,28 @@ modules:
 { pkgs, config, lib, ... }:
 
 let
-  inherit (lib) mkEnableOption mkOption mkMerge mkIf types;
+  inherit (lib) mkEnableOption mkOption mkOptionType mkMerge mkIf types;
   cfg = config.programs.nixvim;
-in {
+in
+{
   options = {
-    programs.nixvim = lib.mkOption {
+    programs.nixvim = mkOption {
       type = types.submodule ((modules pkgs) ++ [{
         options.enable = mkEnableOption "nixvim";
       }]);
     };
+    nixvim.helpers = mkOption {
+      type = mkOptionType {
+        name = "helpers";
+        description = "Helpers that can be used when writing nixvim configs";
+        check = builtins.isAttrs;
+      };
+      description = "Use this option to access the helpers";
+      default = import ../plugins/helpers.nix { inherit (pkgs) lib; };
+    };
   };
 
-  config = mkIf cfg.enable 
+  config = mkIf cfg.enable
     (mkMerge [
       { environment.systemPackages = [ cfg.finalPackage ]; }
       (mkIf (!cfg.wrapRc) {


### PR DESCRIPTION
I believe #51 is overwritten by #48. This is a rebased version.