### PR TITLE
Use init.lua instead of init.vim

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -89,15 +89,16 @@ in
     let
       customRC =
         (optionalString (config.extraConfigLuaPre != "") ''
-          lua <<EOF
           ${config.extraConfigLuaPre}
-          EOF
         '') +
-        config.extraConfigVim + (optionalString (config.extraConfigLua != "" || config.extraConfigLuaPost != "") ''
-          lua <<EOF
+        (optionalString (config.extraConfigVim != "") ''
+          vim.cmd([[
+            ${config.extraConfigVim}
+          ]])
+        '') + 
+        (optionalString (config.extraConfigLua != "" || config.extraConfigLuaPost != "") ''
           ${config.extraConfigLua}
           ${config.extraConfigLuaPost}
-          EOF
         '');
 
       defaultPlugin = {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -17,7 +17,7 @@ in {
     (mkMerge [
       { home.packages = [ cfg.finalPackage ]; }
       (mkIf (!cfg.wrapRc) {
-        xdg.configFile."nvim/init.vim".text = cfg.initContent;
+        xdg.configFile."nvim/init.lua".text = cfg.initContent;
       })
     ]);
 }

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -17,7 +17,7 @@ in {
     (mkMerge [
       { environment.systemPackages = [ cfg.finalPackage ]; }
       (mkIf (!cfg.wrapRc) {
-        environment.etc."nvim/sysinit.vim".text = cfg.initContent;
+        environment.etc."nvim/sysinit.lua".text = cfg.initContent;
         environment.variables."VIM" = "/etc/nvim";
       })
     ]);


### PR DESCRIPTION
PR to use init.lua instead of init.vim. Resolves https://github.com/pta2002/nixvim/issues/63. Vim setup commands are wrapped inside `vim.cmd()` - this results in the following block (example from my own config):
```
vim.cmd([[
  colorscheme nord

command W w
command Q q

augroup lsp
  autocmd!
  autocmd BufWrite,BufEnter,InsertLeave * :lua vim.diagnostic.setloclist({ open = false })
augroup END

augroup vimStart
  autocmd!
  autocmd VimResized * wincmd =
augroup END                                                                                                                                                                               
]])
```
I've tested this with the home-manager install.