### PR TITLE
vuels: using non deprecated version

### DIFF
--- a/plugins/nvim-lsp/basic-servers.nix
+++ b/plugins/nvim-lsp/basic-servers.nix
@@ -72,7 +72,7 @@ let
     {
       name = "vuels";
       description = "Enable vuels, for Vue";
-      packages = [ pkgs.nodePackages.vue-language-server ];
+      packages = [ pkgs.nodePackages.vls ];
     }
     {
       name = "zls";


### PR DESCRIPTION
`vue-language-server` is deprecated and `vls` should be used instead.