### PR TITLE
Wrappers: Extend and document the `makeNixvim` function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,11 +46,14 @@
                 nixvimModules = nixvimModules;
                 inherit nmdSrc;
               };
-
               legacyPackages = rec {
-			    makeNixvimWithPkgs = import ./wrappers/standalone.nix pkgs modules;
-			  	makeNixvim = configuration: makeNixvimWithPkgs {inherit configuration;};
-			   };
+                makeNixvimWithModule = import ./wrappers/standalone.nix pkgs modules;
+                makeNixvim = configuration: makeNixvimWithModule { 
+                  module = {
+                    config = configuration;
+                  };
+                };
+              };
             });
     in
     flakeOutput // {

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,10 @@
                 inherit nmdSrc;
               };
 
-              legacyPackages.makeNixvim = import ./wrappers/standalone.nix pkgs (modules pkgs);
+              legacyPackages = rec {
+			    makeNixvimWithPkgs = import ./wrappers/standalone.nix pkgs modules;
+			  	makeNixvim = configuration: makeNixvimWithPkgs {inherit configuration;};
+			   };
             });
     in
     flakeOutput // {

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,4 +1,4 @@
-default_pkgs: modules: {pkgs ? default_pkgs, configuration}:
+default_pkgs: modules: {pkgs ? default_pkgs, module}:
 
 let
 
@@ -7,7 +7,7 @@ let
   wrap = { wrapRc = true; };
 
   eval = lib.evalModules {
-    modules = (modules pkgs) ++ [ { config = configuration; } wrap ];
+    modules = (modules pkgs) ++ [ module wrap ];
   };
 
 in eval.config.finalPackage

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,4 +1,4 @@
-pkgs: modules: configuration:
+default_pkgs: modules: {pkgs ? default_pkgs, configuration}:
 
 let
 
@@ -7,7 +7,7 @@ let
   wrap = { wrapRc = true; };
 
   eval = lib.evalModules {
-    modules = modules ++ [ { config = configuration; } wrap ];
+    modules = (modules pkgs) ++ [ { config = configuration; } wrap ];
   };
 
 in eval.config.finalPackage


### PR DESCRIPTION
The `build` function has be changed to the `makeNixvim` function. This also adds a full example of flake that allows to include nixvim.