### PR TITLE
tokyonight: Fix configuration and align more with defaults

### DIFF
--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, helpers, ... }:
 with lib;
 let
   cfg = config.colorschemes.tokyonight;
@@ -9,50 +9,86 @@ in
     colorschemes.tokyonight = {
       enable = mkEnableOption "Enable tokyonight";
       style = mkOption {
-        type = types.nullOr style;
-        default = null;
+        type = style;
+        default = "storm";
         description = "Theme style";
       };
-      terminalColors = mkEnableOption
-        "Configure the colors used when opening a :terminal in Neovim";
-      italicComments = mkEnableOption "Make comments italic";
-      italicKeywords = mkEnableOption "Make keywords italic";
-      italicFunctions = mkEnableOption "Make functions italic";
-      italicVariables = mkEnableOption "Make variables and identifiers italic";
+      terminalColors = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Configure the colors used when opening a :terminal in Neovim";
+      };
       transparent =
         mkEnableOption "Enable this to disable setting the background color";
-      hideInactiveStatusline = mkEnableOption
-        "Enabling this option will hide inactive statuslines and replace them with a thin border";
-      transparentSidebar = mkEnableOption
-        "Sidebar like windows like NvimTree get a transparent background";
-      darkSidebar = mkEnableOption
-        "Sidebar like windows like NvimTree get a darker background";
-      darkFloat = mkEnableOption
-        "Float windows like the lsp diagnostics windows get a darker background";
-      lualineBold = mkEnableOption
-        "When true, section headers in the lualine theme will be bold";
+      styles =
+        let
+          mkBackgroundStyle = name: mkOption {
+            type = types.enum [ "dark" "transparent" "normal" ];
+            description = "Background style for ${name}";
+            default = "dark";
+          };
+        in
+        {
+          comments = mkOption {
+            type = types.attrsOf types.anything;
+            description = "Define comments highlight properties";
+            default = { italic = true; };
+          };
+          keywords = mkOption {
+            type = types.attrsOf types.anything;
+            description = "Define keywords highlight properties";
+            default = { italic = true; };
+          };
+          functions = mkOption {
+            type = types.attrsOf types.anything;
+            description = "Define functions highlight properties";
+            default = { };
+          };
+          variables = mkOption {
+            type = types.attrsOf types.anything;
+            description = "Define variables highlight properties";
+            default = { };
+          };
+          sidebars = mkBackgroundStyle "sidebars";
+          floats = mkBackgroundStyle "floats";
+        };
+      sidebars = mkOption {
+        type = types.listOf types.str;
+        default = [ "qf" "help" ];
+        description = "Set a darker background on sidebar-like windows";
+        example = ''["qf" "vista_kind" "terminal" "packer"]'';
+      };
+      dayBrightness = mkOption {
+        type = types.numbers.between 0.0 1.0;
+        default = 0.3;
+        description = "Adjusts the brightness of the colors of the **Day** style";
+      };
+      hideInactiveStatusline =
+        mkEnableOption
+          "Enabling this option will hide inactive statuslines and replace them with a thin border";
+      dimInactive = mkEnableOption "dims inactive windows";
+      lualineBold =
+        mkEnableOption
+          "When true, section headers in the lualine theme will be bold";
     };
   };
   config = mkIf cfg.enable {
     colorscheme = "tokyonight";
     extraPlugins = [ pkgs.vimPlugins.tokyonight-nvim ];
     options = { termguicolors = true; };
-    globals = {
-      tokyonight_style = mkIf (!isNull cfg.style) cfg.style;
-      tokyonight_terminal_colors = mkIf (!cfg.terminalColors) 0;
-
-      tokyonight_italic_comments = mkIf (!cfg.italicComments) 0;
-      tokyonight_italic_keywords = mkIf (!cfg.italicKeywords) 0;
-      tokyonight_italic_functions = mkIf (cfg.italicFunctions) 1;
-      tokyonight_italic_variables = mkIf (cfg.italicVariables) 1;
-
-      tokyonight_transparent = mkIf (cfg.transparent) 1;
-      tokyonight_hide_inactive_statusline =
-        mkIf (cfg.hideInactiveStatusline) 1;
-      tokyonight_transparent_sidebar = mkIf (cfg.transparentSidebar) 1;
-      tokyonight_dark_sidebar = mkIf (!cfg.darkSidebar) 0;
-      tokyonight_dark_float = mkIf (!cfg.darkFloat) 0;
-      tokyonight_lualine_bold = mkIf (cfg.lualineBold) 1;
-    };
+    extraConfigLuaPre =
+      let
+        setupOptions = with cfg; {
+          inherit (cfg) style transparent styles sidebars;
+          terminal_colors = terminalColors;
+          hide_inactive_statusline = hideInactiveStatusline;
+          dim_inactive = dimInactive;
+          lualine_bold = lualineBold;
+          day_brightness = dayBrightness;
+        };
+      in
+      ''
+        require("tokyonight").setup(${helpers.toLuaObject setupOptions})
+      '';
   };
 }


### PR DESCRIPTION
The global variables don't work for applying configuration, we need to switch to using the 'setup' function. This also aligns the default option values in tokyonight upstream.