### PR TITLE
add `magma-nvim` to plugins

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -60,5 +60,6 @@
     ./utils/undotree.nix
     ./utils/dashboard.nix
     ./utils/emmet.nix
+    ./utils/magma-nvim.nix
   ];
 }

--- a/plugins/plugin-defs.nix
+++ b/plugins/plugin-defs.nix
@@ -84,4 +84,42 @@
       sha256 = "sha256-AtkG2XRVZgvJzH2iLr7UT/U1+LXxenvNckdapnJV+8A=";
     };
   };
+
+  magma-nvim = pkgs.vimUtils.buildVimPlugin rec {
+    pname = "magma-nvim";
+    version = "94370733757d550594fe4a1d65643949d7485989";
+
+    src = pkgs.fetchFromGitHub {
+      # using fork of https://github.com/dccsillag/magma-nvim because there are some unmerged
+      # pull requests that I really want
+      owner = "WhiteBlackGoose";
+      repo = "magma-nvim-goose";
+      rev = version;
+      sha256 = "sha256-IaslJK1F2BxTvZzKGH9OKOl2RICi4d4rSgjliAIAqK4=";
+    };
+
+    passthru.python3Dependencies = ps: with ps;  [
+      pynvim
+      jupyter-client
+      ueberzug
+      pillow
+      cairosvg
+      plotly
+      ipykernel
+      pyperclip
+      (ps.buildPythonPackage rec {
+        pname = "pnglatex";
+        version = "1.1";
+        src = fetchPypi {
+          inherit pname version;
+          hash = "sha256-CZUGDUkmttO0BzFYbGFSNMPkWzFC/BW4NmAeOwz4Y9M=";
+        };
+        doCheck = false;
+        meta = with lib; {
+          homepage = "https://github.com/MaT1g3R/pnglatex";
+          description = "a small program that converts LaTeX snippets to png";
+        };
+      })
+    ];
+  };
 }

--- a/plugins/plugin-defs.nix
+++ b/plugins/plugin-defs.nix
@@ -53,7 +53,7 @@
         pname = "std2";
         version = "48bb39b69ed631ef64eed6123443484133fd20fc";
 
-        doCheck = false;
+        doCheck = true;
 
         src = pkgs.fetchFromGitHub {
           owner = "ms-jpq";
@@ -90,13 +90,13 @@
     version = "94370733757d550594fe4a1d65643949d7485989";
 
     src = pkgs.fetchFromGitHub {
-      # using fork of https://github.com/dccsillag/magma-nvim because there are some unmerged
-      # pull requests that I really want
       owner = "WhiteBlackGoose";
       repo = "magma-nvim-goose";
       rev = version;
       sha256 = "sha256-IaslJK1F2BxTvZzKGH9OKOl2RICi4d4rSgjliAIAqK4=";
     };
+
+
 
     passthru.python3Dependencies = ps: with ps;  [
       pynvim

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -1,0 +1,29 @@
+{pkgs,lib,config, ...}:
+with lib;
+let
+  cfg = config.plugins.magma-nvim;
+  helpers = import ../helpers.nix { lib = lib; };
+  plugins = import ../plugin-defs.nix { inherit pkgs; };
+in
+  {
+    options = {
+      plugins.magma-nvim = {
+        enable = mkEnableOption "Enable magma-nvim?";
+        # image_provider
+        # automatically_open_output
+        # wrap_output
+        # output_window_borders
+        # cell_highlight_group
+        # save_path
+        # show_mimetype_debug
+      };
+    };
+    config = mkIf cfg.enable {
+      extraPlugins = [ plugins.magma-nvim ];
+      globals = {
+
+      };
+   };
+
+  }
+

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -1,110 +1,111 @@
-{pkgs,lib,config, ...}:
+{ pkgs, lib, config, ... }:
 with lib;
 let
   cfg = config.plugins.magma-nvim;
-  helpers = import ../helpers.nix { lib = lib; };
   plugins = import ../plugin-defs.nix { inherit pkgs; };
-in
-  {
-    options = {
-      plugins.magma-nvim = {
-        enable = mkEnableOption "Enable magma-nvim?";
-        image_provider = mkOption {
-          type = types.str;
-          default = "none";
-          example = "ueberzug";
-          description = 
-          " This configures how to display images. The following options are available:
-              none -- don't show imagesmagma_image_provider.
-              ueberzug -- use Ueberzug to display images.
-              kitty -- use the Kitty protocol to display images.
-          ";
-        };
-        automatically_open_output = mkOption {
-          type = types.bool;
-          default = true;
-          example = false;
-          description = 
-          "
-          Defaults to v:true.
-            If this is true, then whenever you have an active cell its output window will be automatically shown.
-
-            If this is false, then the output window will only be automatically shown when you've just evaluated the code. So, if you take your cursor out of the cell, and then come back, the output window won't be opened (but the cell will be highlighted). This means that there will be nothing covering your code. You can then open the output window at will using :MagmaShowOutput.
-          ";
-        };
-
-
-        wrap_output = mkOption {
-          type = types.bool;
-          default = true;
-          example = false;
-          description = 
-          "
-          Defaults to v:true.
-            If this is true, then text output in the output window will be wrapped (akin to set wrap).
-          ";
-        };
-
-        output_window_borders = mkOption {
-          type = types.bool;
-          default = true;
-          example = false;
-          description = 
-          "
-          Defaults to v:true.
-            If this is true, then the output window will have rounded borders. If it is false, it will have no borders.
-          ";
-        };
-
-        cell_highlight_group = mkOption {
-          type = types.str;
-          default = "CursorLine";
-          # example = "";
-          description = 
-          "
-          Defaults to CursorLine.
-            The highlight group to be used for highlighting cells.
-          ";
-        };
-        save_path = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = 
-          "
-          Defaults to stdpath(\"data\") .. \"/magma\".
-            Where to save/load with :MagmaSave and :MagmaLoad (with no parameters).
-            The generated file is placed in this directory, with the filename itself being the buffer's name, with % replaced by %% and / replaced by %, and postfixed with the extension .json.
-          ";
-        };
-        show_mimetype_debug = mkOption {
-          type = types.bool;
-          default = false;
-          example = true;
-          description = 
-          "
-          Defaults to v:false.
-            If this is true, then before any non-iostream output chunk, Magma shows the mimetypes it received for it.
-            This is meant for debugging and adding new mimetypes.
-          ";
-        };
-
-      };
+  package = pkgs.fetchFromGitHub {
+      owner = "dccsillag";
+      repo = "magma-nvim";
+      rev = version;
+      sha256 = "sha256-IaslJK1F2BxTvZzKGH9OKOl2RICi4d4rSgjliAIAqK4=";
     };
-    config = mkIf cfg.enable {
-      extraPlugins = [ plugins.magma-nvim ];
-      globals = {
-        magma_image_provider = mkIf (cfg.image_provider != "none") cfg.image_provider;
-        magma_automatically_open_output = mkIf (! cfg.automatically_open_output ) cfg.automatically_open_output;
-        magma_wrap_output = mkIf (! cfg.wrap_output ) cfg.wrap_output;
-        magma_output_window_borders = mkIf (! cfg.output_window_borders ) cfg.output_window_borders;
-        magma_highlight_group = mkIf (cfg.cell_highlight_group != "CursorLine") cfg.cell_highlight_group;
-        magma_show_mimetype_debug = mkIf cfg.show_mimetype_debug cfg.show_mimetype_debug;
+in {
+  options = {
+    plugins.magma-nvim = {
+      enable = mkEnableOption "Enable magma-nvim?";
+      image_provider = mkOption {
+        type = types.enum [ "none" "ueberzug" "kitty" ];
+        default = "none";
+        example = "ueberzug";
+        description =
+          " This configures how to display images. The following options are available:
+          none -- don't show imagesmagma_image_provider.
+          ueberzug -- use Ueberzug to display images.
+          kitty -- use the Kitty protocol to display images.";
+      };
+      automatically_open_output = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description =
+          " If this is true, then whenever you have an active cell its output window will be automatically shown.
+          If this is false, then the output window will only be automatically shown when you've just evaluated the code. So, if you take your cursor out of the cell, and then come back, the output window won't be opened (but the cell will be highlighted). This means that there will be nothing covering your code. You can then open the output window at will using :MagmaShowOutput.";
+      };
 
+      wrap_output = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description =
+          " If this is true, then text output in the output window will be wrapped (akin to set wrap).";
+      };
 
+      output_window_borders = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description =
+          " If this is true, then the output window will have rounded borders. If it is false, it will have no borders.";
+      };
 
+      cell_highlight_group = mkOption {
+        type = types.str;
+        default = "CursorLine";
+        # example = "";
+        description =
+          " The highlight group to be used for highlighting cells.";
+      };
+      save_path = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description =
+          "Where to save/load with :MagmaSave and :MagmaLoad (with no parameters).
+          The generated file is placed in this directory, with the filename itself being the buffer's name, with % replaced by %% and / replaced by %, and postfixed with the extension .json.";
+      };
+      show_mimetype_debug = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description =
+          " If this is true, then before any non-iostream output chunk, Magma shows the mimetypes it received for it.
+          This is meant for debugging and adding new mimetypes.";
+      };
+      package = mkOption {
+        type = types.nullOr types.package;
+        default = null;
+        example = 
+        "package = pkgs.fetchFromGitHub {
+          owner = \"WhiteBlackGoose\";
+          repo = \"magma-nvim-goose\";
+          rev = version;
+          sha256 = \"sha256-IaslJK1F2BxTvZzKGH9OKOl2RICi4d4rSgjliAIAqK4=\";} ";
+        
 
       };
-   };
 
-  }
+    };
+  };
+  config = mkIf cfg.enable {
+    extraPlugins = [ ( 
+      if cfg.package != null then plugins.magma-nvim.override {src = cfg.package;} else plugins.magma-nvim 
+    )];
+
+
+    globals = {
+      magma_image_provider =
+        mkIf (cfg.image_provider != "none") cfg.image_provider;
+      magma_automatically_open_output =
+        mkIf (!cfg.automatically_open_output) cfg.automatically_open_output;
+      magma_wrap_output = mkIf (!cfg.wrap_output) cfg.wrap_output;
+      magma_output_window_borders =
+        mkIf (!cfg.output_window_borders) cfg.output_window_borders;
+      magma_highlight_group = mkIf (cfg.cell_highlight_group != "CursorLine")
+        cfg.cell_highlight_group;
+      magma_show_mimetype_debug =
+        mkIf cfg.show_mimetype_debug cfg.show_mimetype_debug;
+
+    };
+  };
+
+}
 

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -9,18 +9,99 @@ in
     options = {
       plugins.magma-nvim = {
         enable = mkEnableOption "Enable magma-nvim?";
-        # image_provider
-        # automatically_open_output
-        # wrap_output
-        # output_window_borders
-        # cell_highlight_group
-        # save_path
-        # show_mimetype_debug
+        image_provider = mkOption {
+          type = types.str;
+          default = "none";
+          example = "ueberzug";
+          description = 
+          " This configures how to display images. The following options are available:
+              none -- don't show imagesmagma_image_provider.
+              ueberzug -- use Ueberzug to display images.
+              kitty -- use the Kitty protocol to display images.
+          ";
+        };
+        automatically_open_output = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = 
+          "
+          Defaults to v:true.
+            If this is true, then whenever you have an active cell its output window will be automatically shown.
+
+            If this is false, then the output window will only be automatically shown when you've just evaluated the code. So, if you take your cursor out of the cell, and then come back, the output window won't be opened (but the cell will be highlighted). This means that there will be nothing covering your code. You can then open the output window at will using :MagmaShowOutput.
+          ";
+        };
+
+
+        wrap_output = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = 
+          "
+          Defaults to v:true.
+            If this is true, then text output in the output window will be wrapped (akin to set wrap).
+          ";
+        };
+
+        output_window_borders = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = 
+          "
+          Defaults to v:true.
+            If this is true, then the output window will have rounded borders. If it is false, it will have no borders.
+          ";
+        };
+
+        cell_highlight_group = mkOption {
+          type = types.str;
+          default = "CursorLine";
+          # example = "";
+          description = 
+          "
+          Defaults to CursorLine.
+            The highlight group to be used for highlighting cells.
+          ";
+        };
+        save_path = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = 
+          "
+          Defaults to stdpath(\"data\") .. \"/magma\".
+            Where to save/load with :MagmaSave and :MagmaLoad (with no parameters).
+            The generated file is placed in this directory, with the filename itself being the buffer's name, with % replaced by %% and / replaced by %, and postfixed with the extension .json.
+          ";
+        };
+        show_mimetype_debug = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = 
+          "
+          Defaults to v:false.
+            If this is true, then before any non-iostream output chunk, Magma shows the mimetypes it received for it.
+            This is meant for debugging and adding new mimetypes.
+          ";
+        };
+
       };
     };
     config = mkIf cfg.enable {
       extraPlugins = [ plugins.magma-nvim ];
       globals = {
+        magma_image_provider = mkIf (cfg.image_provider != "none") cfg.image_provider;
+        magma_automatically_open_output = mkIf (! cfg.automatically_open_output ) cfg.automatically_open_output;
+        magma_wrap_output = mkIf (! cfg.wrap_output ) cfg.wrap_output;
+        magma_output_window_borders = mkIf (! cfg.output_window_borders ) cfg.output_window_borders;
+        magma_highlight_group = mkIf (cfg.cell_highlight_group != "CursorLine") cfg.cell_highlight_group;
+        magma_show_mimetype_debug = mkIf cfg.show_mimetype_debug cfg.show_mimetype_debug;
+
+
+
 
       };
    };


### PR DESCRIPTION
[magma-nvim ](https://github.com/dccsillag/magma-nvim) allows you to execute python files as if they were Jupyter notebooks right from inside Neovim. I have added all global options as well, with documentation. I am using the [magama-nvim-goose](https://github.com/WhiteBlackGoose/magma-nvim-goose) fork until their upstream merges their [#69](https://github.com/dccsillag/magma-nvim/pull/69) which allows for external kernels. 

(unrelated, this is my first open source pull request, so am a little excited)