### PR TITLE
null-ls: Add gitsigns code action

### DIFF
--- a/plugins/null-ls/servers.nix
+++ b/plugins/null-ls/servers.nix
@@ -2,7 +2,9 @@
 let
   helpers = import ./helpers.nix args;
   serverData = {
-    code_actions = { };
+    code_actions = { 
+      gitsigns = { };
+    };
     completion = { };
     diagnostics = {
       flake8 = {
@@ -54,4 +56,11 @@ let
 in
 {
   imports = lib.lists.map (helpers.mkServer) dataFlattened;
+
+  config = let
+    cfg = config.plugins.null-ls;
+  in
+    lib.mkIf cfg.enable {
+      plugins.gitsigns.enable = lib.mkIf (cfg.sources.code_actions.gitsigns.enable) true;
+    };
 }


### PR DESCRIPTION
As this is not an external command but a plugin it adds the gitsigns plugin if enabled.