### PR TITLE
nvim-tree: typo in option updateFocusedFile

### DIFF
--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -227,7 +227,7 @@ in
           auto_open = cfg.updateToBufDir.autoOpen;
         };
         diagnostics = cfg.diagnostics;
-        updateFocusedFile = {
+        update_focused_file = {
           enable = cfg.updateFocusedFile.enable;
           update_cwd = cfg.updateFocusedFile.updateCwd;
           ignore_list = cfg.updateFocusedFile.ignoreList;


### PR DESCRIPTION
In the implementation, the option `updateFocusedFile` was not written correctly:

`updateFocusedFile` --> `update_focused_file`