### PR TITLE
modules/keymaps: switch to lua API vim.keymap.set

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -117,14 +117,13 @@ in
         (helpers.genMaps "c" config.maps.command);
     in
     {
-      # TODO: Use vim.keymap.set if on nvim >= 0.7
       extraConfigLua = optionalString (mappings != [ ]) ''
         -- Set up keybinds {{{
         do
           local __nixvim_binds = ${helpers.toLuaObject mappings}
 
           for i, map in ipairs(__nixvim_binds) do
-            vim.api.nvim_set_keymap(map.mode, map.key, map.action, map.config)
+            vim.keymap.set(map.mode, map.key, map.action, map.config)
           end
         end
         -- }}}

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -81,6 +81,10 @@
               };
             };
 
+            keymaps = build {
+              maps.normal."," = "<cmd>echo \"test\"<cr>";
+            };
+
             issue-40 = build-stable {
               plugins = {
                 nix.enable = true;


### PR DESCRIPTION
This is a very basic edit to `modules/keymaps.nix` to adopt the Lua API way of setting keymaps, i.e. `vim.keymap.set`.
I do not know if it is necessary nor possible to make this depend on neovim version.

If so, here is what it would look like:
```
  config =
    let
      mappingFunctionString = if NEOVIM_IS_NEWER_THAN_0_7
        then
            "vim.keymap.set(map.mode, map.key, map.action, map.config)"
        else
            "vim.api.nvim_set_keymap(map.mode, map.key, map.action, map.config)"
      ;
      mappings =
        (helpers.genMaps "" config.maps.normalVisualOp) ++
        (helpers.genMaps "n" config.maps.normal) ++
        (helpers.genMaps "i" config.maps.insert) ++
        (helpers.genMaps "v" config.maps.visual) ++
        (helpers.genMaps "x" config.maps.visualOnly) ++
        (helpers.genMaps "s" config.maps.select) ++
        (helpers.genMaps "t" config.maps.terminal) ++
        (helpers.genMaps "o" config.maps.operator) ++
        (helpers.genMaps "l" config.maps.lang) ++
        (helpers.genMaps "!" config.maps.insertCommand) ++
        (helpers.genMaps "c" config.maps.command);
    in
    {
      extraConfigLua = optionalString (mappings != [ ]) ''
        -- Set up keybinds {{{
        do
          local __nixvim_binds = ${helpers.toLuaObject mappings}

          for i, map in ipairs(__nixvim_binds) do
            ${mappingFunctionString}
          end
        end
        -- }}}
      '';
    };
}
```