### PR TITLE
plugins/languages/treesitter: fixed parsers installation when not using nixGrammars

### DIFF
--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -112,10 +112,10 @@ in
       } // cfg.moduleConfig;
     in
     mkIf cfg.enable {
-      extraConfigLua = ''
-        require('nvim-treesitter.configs').setup(${helpers.toLuaObject tsOptions})
-      '' + optionalString (cfg.parserInstallDir != null) ''
+      extraConfigLua = (optionalString (cfg.parserInstallDir != null) ''
         vim.opt.runtimepath:append("${cfg.parserInstallDir}")
+      '') + ''
+        require('nvim-treesitter.configs').setup(${helpers.toLuaObject tsOptions})
       '';
 
       extraPlugins = with pkgs; if cfg.nixGrammars then


### PR DESCRIPTION
When setting a custom `parserInstallDir` in treesitter, the given path [has to be added to the vim runtimepath](https://github.com/nvim-treesitter/nvim-treesitter/issues/3605#issuecomment-1299954399).
Otherwise, the parsers are not getting detected by treesitter who is reinstalling them at each startup of neovim.

This was already done in the module, but **after** the `require('nvim-treesitter.configs').setup()` call.
But this needs to be **before**.
This PR adds the path to the vim runtimepath before calling the `treesitter` setup function.