### PR TITLE
plugins/languages/treesitter: change default value for parserInstallDir

### DIFF
--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -23,13 +23,15 @@ in
 
       parserInstallDir = mkOption {
         type = types.nullOr types.str;
-        default = if cfg.nixGrammars
-          then
-            null
-          else
-            "$XDG_DATA_HOME/nvim/treesitter"
+        default =
+          if cfg.nixGrammars
+          then null
+          else "$XDG_DATA_HOME/nvim/treesitter"
         ;
-        description = "Location of the parsers to be installed by the plugin (only needed when nixGrammars is disabled)";
+        description = ''
+          Location of the parsers to be installed by the plugin (only needed when nixGrammars is disabled).
+          This default might not work on your own install, please make sure that $XDG_DATA_HOME is set if you want to use the default. Otherwise, change it to something that will work for you!
+        '';
       };
 
       ignoreInstall = mkOption {
@@ -79,7 +81,7 @@ in
 
       moduleConfig = mkOption {
         type = types.attrsOf types.anything;
-        default = {};
+        default = { };
         description = "This is the configuration for extra modules. It should not be used directly";
       };
     };

--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -23,7 +23,12 @@ in
 
       parserInstallDir = mkOption {
         type = types.nullOr types.str;
-        default = null;
+        default = if cfg.nixGrammars
+          then
+            null
+          else
+            "$XDG_DATA_HOME/nvim/treesitter"
+        ;
         description = "Location of the parsers to be installed by the plugin (only needed when nixGrammars is disabled)";
       };
 


### PR DESCRIPTION
Currently, the `nixGrammars = true` method for installing parsers is [broken](https://github.com/pta2002/nixvim/issues/102).

Fortunately, nixvim also supports the _legacy_ way of installing parsers.
The problem is that treesitter tries to put the parsers in its package directory which is not writable when using NixOS.
This can be overcome by setting a custom directory using the `parserInstallDir` option.

This PR proposes to change the default value for this option **when `nixGrammar` is set to `false`** to `$XDG_DATA_HOME/nvim/treesitter`.
Hence, when a NixOS user wants to use the legacy way of installing parsers, he only has to set `nixGrammar` to `false`.