### PR TITLE
plugins/utils/startify: fix wrongly named option: startify_custom_header

### DIFF
--- a/plugins/utils/startify.nix
+++ b/plugins/utils/startify.nix
@@ -182,7 +182,7 @@ mkPlugin args {
 
     customHeader = mkDefaultOpt {
       description = "Define your own header";
-      global = "startify_custom_headers";
+      global = "startify_custom_header";
       type = types.oneOf [ types.str (types.listOf types.str) ];
     };
 


### PR DESCRIPTION
The nix option `customHeader` should map to the global `startify_custom_header` and not `startify_custom_headers` (extra 's' at the end)