### PR TITLE
plugins/completion/nvim-cmp: add missing type of option "auto_enable_sources"

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -209,6 +209,7 @@ in
     };
 
     auto_enable_sources = mkOption {
+      type = types.bool;
       default = true;
       description = ''
         Scans the sources array and installs the plugins if they are known to nixvim.


### PR DESCRIPTION
The option `auto_enable_sources` of the `plugins.nvim-cmp` module is lacking the type declaration.