### PR TITLE
modules/keymaps: add option silentDefault

### DIFF
--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  helpers = import ../plugins/helpers.nix { inherit lib; };
+  helpers = import ../plugins/helpers.nix { inherit config lib; };
 in
 with lib;
 {

--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 with lib;
 let
-  helpers = import ../plugins/helpers.nix { inherit lib; };
+  helpers = import ../plugins/helpers.nix { inherit config lib; };
 
   mapOption = types.oneOf [
     types.str
@@ -10,7 +10,8 @@ let
         silent = mkOption {
           type = types.bool;
           description = "Whether this mapping should be silent. Equivalent to adding <silent> to a map.";
-          default = false;
+          # default = config.maps.silentDefault;
+          default = true;
         };
 
         nowait = mkOption {
@@ -80,6 +81,12 @@ in
           insertCommand = mapOptions "insert and command-line";
           lang = mapOptions "insert, command-line and lang-arg";
           command = mapOptions "command-line";
+
+          silentDefault = mkOption {
+            description = "Makes all mapping silent by default";
+            type = types.bool;
+            default = false;
+          };
         };
       };
       default = { };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 with lib;
 let
-  helpers = import ../plugins/helpers.nix { inherit lib; };
+  helpers = import ../plugins/helpers.nix { inherit config lib; };
 in
 {
   options = {

--- a/plugins/completion/nvim-cmp/cmp-helpers.nix
+++ b/plugins/completion/nvim-cmp/cmp-helpers.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../../helpers.nix { lib = lib; };
+  helpers = import ../../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 {
   mkCmpSourcePlugin = { name, extraPlugins ? [], useDefaultPackage ? true, ... }: mkPlugin attrs {

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -1,8 +1,8 @@
-{ pkgs, config, lib, ... }@args:
+{ config, lib, pkgs, ... }@args:
 with lib;
 let
   cfg = config.plugins.nvim-cmp;
-  helpers = import ../../helpers.nix { lib = lib; };
+  helpers = import ../../helpers.nix { inherit config lib; };
   mkNullOrOption = helpers.mkNullOrOption;
   cmpLib = import ./cmp-helpers.nix args;
   # functionName should be a string

--- a/plugins/git/fugitive.nix
+++ b/plugins/git/fugitive.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "fugitive";

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 with lib;
 rec {
   # vim dictionaries are, in theory, compatible with JSON
@@ -40,7 +40,7 @@ rec {
     normalized = builtins.mapAttrs (key: action:
       if builtins.isString action then
         {
-          silent = false;
+          silent = config.maps.silentDefault;
           expr = false;
           unique = false;
           noremap = true;

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -1,5 +1,5 @@
-{ pkgs, lib, ... }@args:
-with lib; with import ../helpers.nix { lib = lib; };
+{ config, lib, pkgs, ... }@args:
+with lib; with import ../helpers.nix { inherit config lib; };
 mkPlugin args {
   name = "ledger";
   description = "Enable ledger language features";

--- a/plugins/languages/nix.nix
+++ b/plugins/languages/nix.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "nix";

--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -1,8 +1,8 @@
-{ pkgs, lib, config, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.treesitter;
-  helpers = import ../helpers.nix { inherit lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in
 {
   options = {

--- a/plugins/languages/zig.nix
+++ b/plugins/languages/zig.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "zig";

--- a/plugins/nvim-lsp/default.nix
+++ b/plugins/nvim-lsp/default.nix
@@ -1,8 +1,8 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.lsp;
-  helpers = (import ../helpers.nix { inherit lib; });
+  helpers = (import ../helpers.nix { inherit config lib; });
 in
 {
   imports = [

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -1,8 +1,8 @@
-{ pkgs, config, lib, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.telescope;
-  helpers = (import ../helpers.nix { inherit lib; });
+  helpers = (import ../helpers.nix { inherit config lib; });
 in
 {
   imports = [
@@ -62,7 +62,7 @@ in
       let $BAT_THEME = '${cfg.highlightTheme}'
     '';
 
-    extraConfigLua = let 
+    extraConfigLua = let
       options = {
         extensions = cfg.extensionConfig;
         defaults = cfg.defaults;

--- a/plugins/utils/comment-nvim.nix
+++ b/plugins/utils/comment-nvim.nix
@@ -1,8 +1,8 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.comment-nvim;
-  helpers = import ../helpers.nix { inherit lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in
 {
   options = {

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 with lib;
 let
-  helpers = import ../helpers.nix { inherit lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 
   eitherAttrsStrInt = with types; let
     strInt = either str int;

--- a/plugins/utils/endwise.nix
+++ b/plugins/utils/endwise.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "endwise";

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "goyo";

--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -1,8 +1,8 @@
-{ pkgs, config, lib, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.nvim-tree;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in
 {
   options.plugins.nvim-tree = {

--- a/plugins/utils/project-nvim.nix
+++ b/plugins/utils/project-nvim.nix
@@ -1,8 +1,8 @@
-{ pkgs, config, lib, ... }:
+{ config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.plugins.project-nvim;
-  helpers = import ../helpers.nix { inherit lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in
 {
   options.plugins.project-nvim = helpers.extraOptionsOptions // {

--- a/plugins/utils/startify.nix
+++ b/plugins/utils/startify.nix
@@ -1,6 +1,6 @@
-{ pkgs, lib, ... }@args:
+{ config, lib, pkgs, ... }@args:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with lib; with helpers;
 mkPlugin args {
   name = "startify";

--- a/plugins/utils/surround.nix
+++ b/plugins/utils/surround.nix
@@ -1,6 +1,6 @@
-{ lib, pkgs, ... }@attrs:
+{ config, lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit config lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "surround";


### PR DESCRIPTION
Ok, this one might be rejected, but I wanted to give it a try.
Personally, I want all my mapping being silent.
In the current state, it would force me to explicitly set the `silent` attribute to `true` for each keymap.

With this PR, I propose to add an extra option: `maps.silentDefault` (`bool`) that sets the default value of the `maps.*.*.silent` attribute.

Unfortunately, it forced me to add `config` to the `helpers.nix` arguments which lead to several file changes.

If you are fine with this approach, we could add the same for the other options: `nowait`, `script`, `expr`, `unique` and `noremap`.