### PR TITLE
plugins/utils/nvim-tree: change implementation of autoClose

### DIFF
--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -217,7 +217,6 @@ in
         hijack_netrw = cfg.hijackNetrw;
         open_on_setup = cfg.openOnSetup;
         ignore_ft_on_setup = cfg.ignoreFtOnSetup;
-        auto_close = cfg.autoClose;
         open_on_tab = cfg.openOnTab;
         hijack_cursor = cfg.hijackCursor;
         update_cwd = cfg.updateCwd;
@@ -259,6 +258,14 @@ in
       extraPlugins = with pkgs.vimPlugins; [
         nvim-tree-lua
         nvim-web-devicons
+      ];
+
+      autoCmd = mkIf cfg.autoClose [
+        {
+          event = "BufEnter";
+          command = "if winnr('$') == 1 && bufname() == 'NvimTree_' . tabpagenr() | quit | endif";
+          nested = true;
+        }
       ];
 
       extraConfigLua = ''


### PR DESCRIPTION
The `auto_close` option of `nvim-tree` was removed in upstream by [this commit](https://github.com/nvim-tree/nvim-tree.lua/commit/524758a207f9c5bf3888b446d9f93192a837b8a7).
The plugin author suggests to implement it using the following autocommand:
```vim
autocmd BufEnter * ++nested if winnr('$') == 1 && bufname() == 'NvimTree_' . tabpagenr() | quit | endif
```

This is what this PR does.
~~**WARNING:** This code uses the non-merged-yet `nixvim.autoCmd` module. Hence, [this other PR](https://github.com/pta2002/nixvim/pull/120) has to be merged before.~~