### PR TITLE
null-ls: fix wrong name of variable

### DIFF
--- a/plugins/null-ls/helpers.nix
+++ b/plugins/null-ls/helpers.nix
@@ -41,7 +41,7 @@
 
         config = mkIf cfg.enable {
           # Does this evaluate package?
-          extraPackages = packages ++ optional (package != null) cfg.package;
+          extraPackages = extraPackages ++ optional (package != null) cfg.package;
 
           # Add source to list of sources
           plugins.null-ls.sourcesItems =


### PR DESCRIPTION
The variable wasn't changed to it's new name