### PR TITLE
tree-sitter: Switch to using nvim-treesitter grammars

### DIFF
--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -81,7 +81,7 @@ in
 
       grammarPackages = mkOption {
         type = with types; listOf package;
-        default = pkgs.tree-sitter.allGrammars;
+        default = cfg.package.passthru.allGrammars;
         description = "Grammar packages to install";
       };
 


### PR DESCRIPTION
The grammars in the tree-sitter package and nvim-treesitter package are not the same. The grammars in the nvim-treesitter package are directly taken from the grammars supported by the plugin, whereas tree-sitter grammars are hard-coded in nixpkgs.

This means that there are more tree-sitter grammars available from nvim-treesitter rather than tree-sitter.