### PR TITLE
plugins: Add nvim-lightbulb

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -35,6 +35,7 @@
     ./nvim-lsp
     ./nvim-lsp/lspsaga.nix
     ./nvim-lsp/lsp-lines.nix
+    ./nvim-lsp/nvim-lightbulb.nix
     ./nvim-lsp/trouble.nix
 
     ./pluginmanagers/packer.nix

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -66,6 +66,20 @@ rec {
     description = desc;
   };
 
+  defaultNullOpts = rec {
+    mkNullable = type: default: desc: mkNullOrOption type (let
+      defaultDesc = "default: `${default}`";
+    in if desc == "" then defaultDesc else ''
+      ${desc}
+
+      ${defaultDesc}
+    '');
+
+    mkInt = default: mkNullable lib.types.int (toString default);
+    mkBool = default: mkNullable lib.types.bool (toString default);
+    mkStr = default: mkNullable lib.types.str ''"${default}"'';
+  };
+
   mkPlugin = { config, lib, ... }: {
     name,
     description,

--- a/plugins/nvim-lsp/nvim-lightbulb.nix
+++ b/plugins/nvim-lsp/nvim-lightbulb.nix
@@ -7,7 +7,7 @@
 }:
 with lib; {
   options.plugins.nvim-lightbulb = {
-    enable = mkEnableOption "Enable nvim-lightbulb, showing available code actions";
+    enable = mkEnableOption "nvim-lightbulb, showing available code actions";
 
     package = mkOption {
       type = types.package;

--- a/plugins/nvim-lsp/nvim-lightbulb.nix
+++ b/plugins/nvim-lsp/nvim-lightbulb.nix
@@ -1,0 +1,93 @@
+{
+  pkgs,
+  lib,
+  config,
+  helpers,
+  ...
+}:
+with lib; {
+  options.plugins.nvim-lightbulb = {
+    enable = mkEnableOption "Enable nvim-lightbulb, showing available code actions";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vimPlugins.nvim-lightbulb;
+      description = "Plugin to use for nvim-lightbulb";
+    };
+
+    ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      LSP client names to ignore
+    '';
+
+    sign = {
+      enabled = helpers.defaultNullOpts.mkBool true "";
+      priority = helpers.defaultNullOpts.mkInt 10 "";
+    };
+
+    float = {
+      enabled = helpers.defaultNullOpts.mkBool false "";
+
+      text = helpers.defaultNullOpts.mkStr "💡" "Text to show in the popup float";
+
+      winOpts = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" ''
+        Options for the floating window (see |vim.lsp.util.open_floating_preview| for more information)
+      '';
+    };
+
+    virtualText = {
+      enabled = helpers.defaultNullOpts.mkBool false "";
+
+      text = helpers.defaultNullOpts.mkStr "💡" "Text to show at virtual text";
+
+      hlMode = helpers.defaultNullOpts.mkStr "replace" ''
+        highlight mode to use for virtual text (replace, combine, blend), see
+        :help nvim_buf_set_extmark() for reference
+      '';
+    };
+
+    statusText = {
+      enabled = helpers.defaultNullOpts.mkBool false "";
+
+      text = helpers.defaultNullOpts.mkStr "💡" "Text to provide when code actions are available";
+
+      textUnavailable = helpers.defaultNullOpts.mkStr "" ''
+        Text to provide when no actions are available
+      '';
+    };
+
+    autocmd = {
+      enabled = helpers.defaultNullOpts.mkBool false "";
+
+      pattern = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["*"]'' "";
+
+      events =
+        helpers.defaultNullOpts.mkNullable (types.listOf types.str)
+        ''["CursorHold" "CursorHoldI"]'' "";
+    };
+  };
+
+  config = let
+    cfg = config.plugins.nvim-lightbulb;
+    setupOptions = {
+      inherit (cfg) ignore sign autocmd;
+      float = {
+        inherit (cfg.float) enabled text;
+        win_opts = cfg.float.winOpts;
+      };
+      virtual_text = {
+        inherit (cfg.virtualText) enabled text;
+        hl_mode = cfg.virtualText.hlMode;
+      };
+      status_text = {
+        inherit (cfg.statusText) enabled text;
+        text_unavailable = cfg.statusText.textUnavailable;
+      };
+    };
+  in
+    mkIf cfg.enable {
+      extraPlugins = [cfg.package];
+      extraConfigLua = ''
+        require("nvim-lightbulb").setup(${helpers.toLuaObject setupOptions})
+      '';
+    };
+}


### PR DESCRIPTION
nvim-lightbulb is a plugin showing if code actions are available under the cursor.