### PR TITLE
nvim-lsp: Put LSP settings options in their own namespaces

### DIFF
--- a/plugins/nvim-lsp/basic-servers.nix
+++ b/plugins/nvim-lsp/basic-servers.nix
@@ -23,7 +23,7 @@ let
       name = "dartls";
       description = "Enable dart language-server, for dart";
       package = pkgs.dart;
-      extraOptions = {
+      settingsOptions = {
         analysisExcludedFolders = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
@@ -152,7 +152,7 @@ let
       name = "nil_ls";
       description = "Enable nil, for Nix";
       package = pkgs.nil;
-      extraOptions = {
+      settingsOptions = {
         formatting.command = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
@@ -198,7 +198,7 @@ let
       description = "Enable rust-analyzer, for Rust.";
       serverName = "rust_analyzer";
 
-      extraOptions = import ./rust-analyzer-config.nix lib;
+      settingsOptions = import ./rust-analyzer-config.nix lib;
       settings = cfg: { rust-analyzer = cfg; };
     }
     {

--- a/plugins/nvim-lsp/helpers.nix
+++ b/plugins/nvim-lsp/helpers.nix
@@ -9,7 +9,7 @@
     , extraPackages ? { }
     , cmd ? (cfg: null)
     , settings ? (cfg: { })
-    , extraOptions ? { }
+    , settingsOptions ? { }
     , ...
     }:
     # returns a module
@@ -30,7 +30,8 @@
         options = {
           plugins.lsp.servers.${name} = {
             enable = mkEnableOption description;
-          } // packageOption // extraOptions;
+            settings = settingsOptions;
+          } // packageOption;
         };
 
         config = mkIf cfg.enable
@@ -42,7 +43,7 @@
               name = serverName;
               extraOptions = {
                 cmd = cmd cfg;
-                settings = settings cfg;
+                settings = settings cfg.settings;
               };
             }];
           };


### PR DESCRIPTION
Those two options don't control the server settings, and trying to add them in a settings object can result in strange (and broken) behaviour.

Fixes #135