### PR TITLE
helpers: add mkPackageOption + refactoring

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
                   modules = nixvimModules;
                 };
                 runUpdates = pkgs.callPackage
-                  ({ pkgs, stdenv }: stdenv.mkDerivation { 
+                  ({ pkgs, stdenv }: stdenv.mkDerivation {
                     pname = "run-updates";
                     version = pkgs.rust-analyzer.version;
 
@@ -67,7 +67,7 @@
                     nativeBuildInputs = with pkgs; [extractRustAnalyzerPkg alejandra nixpkgs-fmt];
 
                     buildPhase = ''
-                      extract_rust_analyzer.py editors/code/package.json | 
+                      extract_rust_analyzer.py editors/code/package.json |
                         alejandra --quiet |
                         nixpkgs-fmt > rust-analyzer-config.nix
                     '';

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -90,6 +90,12 @@ rec {
     mkStr = default: mkNullable lib.types.str ''"${default}"'';
   };
 
+  mkPackageOption = name: default: mkOption {
+    type = types.package;
+    inherit default;
+    description = "Plugin to use for ${name}";
+  };
+
   mkPlugin = { config, lib, ... }: { name
                                    , description
                                    , package ? null
@@ -110,11 +116,7 @@ rec {
         options;
       # does this evaluate package?
       packageOption = if package == null then { } else {
-        package = mkOption {
-          type = types.package;
-          default = package;
-          description = "Plugin to use for ${name}";
-        };
+        package = mkPackageOption name package;
       };
     in
     {

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -2,16 +2,13 @@
 with lib;
 let
   cfg = config.plugins.barbar;
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options.plugins.barbar = {
     enable = mkEnableOption "barbar.nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.barbar-nvim;
-      description = "Plugin to use for barbar";
-    };
+    package = helpers.mkPackageOption "barbar" pkgs.vimPlugins.barbar-nvim;
 
     animations = mkOption {
       type = types.nullOr types.bool;

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -34,11 +34,7 @@ in
   options = {
     plugins.bufferline = {
       enable = mkEnableOption "bufferline";
-      package = mkOption {
-        type = types.package;
-        description = "Plugin to use for bufferline";
-        default = pkgs.vimPlugins.bufferline-nvim;
-      };
+      package = helpers.mkPackageOption "bufferline" pkgs.vimPlugins.bufferline-nvim;
       numbers = mkOption {
         type = types.nullOr types.lines;
         description = "A lua function customizing the styling of numbers.";

--- a/plugins/colorschemes/base16.nix
+++ b/plugins/colorschemes/base16.nix
@@ -2,6 +2,7 @@
 with lib;
 let
   cfg = config.colorschemes.base16;
+  helpers = import ../helpers.nix { inherit lib; };
   themes = import ./base16-list.nix;
 in
 {
@@ -9,11 +10,7 @@ in
     colorschemes.base16 = {
       enable = mkEnableOption "base16";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.base16-vim;
-        description = "Plugin to use for base16";
-      };
+      package = helpers.mkPackageOption "base16" pkgs.vimPlugins.base16-vim;
 
       useTruecolor = mkOption {
         type = types.bool;

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -2,6 +2,7 @@
 with lib;
 let
   cfg = config.colorschemes.gruvbox;
+  helpers = import ../helpers.nix { inherit lib; };
   colors = types.enum [ "bg" "red" "green" "yellow" "blue" "purple" "aqua" "gray" "fg" "bg0_h" "bg0" "bg1" "bg2" "bg3" "bg4" "gray" "orange" "bg0_s" "fg0" "fg1" "fg2" "fg3" "fg4" ];
 in
 {
@@ -9,11 +10,7 @@ in
     colorschemes.gruvbox = {
       enable = mkEnableOption "gruvbox";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.gruvbox-nvim;
-        description = "Plugin to use for gruvbox";
-      };
+      package = helpers.mkPackageOption "gruvbox" pkgs.vimPlugins.gruvbox-nvim;
 
       italics = mkEnableOption "italics";
       bold = mkEnableOption "bold";

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -2,17 +2,14 @@
 with lib;
 let
   cfg = config.colorschemes.nord;
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options = {
     colorschemes.nord = {
       enable = mkEnableOption "nord";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.nord-nvim;
-        description = "Plugin to use for nord.nvim";
-      };
+      package = helpers.mkPackageOption "nord.vim" pkgs.vimPlugins.nord-nvim;
 
       contrast = mkEnableOption
         "Make sidebars and popup menus like nvim-tree and telescope have a different background";

--- a/plugins/colorschemes/one.nix
+++ b/plugins/colorschemes/one.nix
@@ -2,17 +2,14 @@
 with lib;
 let
   cfg = config.colorschemes.one;
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options = {
     colorschemes.one = {
       enable = mkEnableOption "vim-one";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.vim-one;
-        description = "Plugin to use for one";
-      };
+      package = helpers.mkPackageOption "one" pkgs.vimPlugins.vim-one;
     };
   };
 

--- a/plugins/colorschemes/onedark.nix
+++ b/plugins/colorschemes/onedark.nix
@@ -8,11 +8,7 @@ in
     colorschemes.onedark = {
       enable = mkEnableOption "onedark";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.onedark-vim;
-        description = "Plugin to use for one";
-      };
+      package = helpers.mkPackageOption "one" pkgs.vimPlugins.onedark-vim;
     };
   };
 

--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -9,11 +9,7 @@ in
   options = {
     colorschemes.tokyonight = {
       enable = mkEnableOption "tokyonight";
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.tokyonight-nvim;
-        description = "Plugin to use for tokyonight";
-      };
+      package = helpers.mkPackageOption "tokyonight" pkgs.vimPlugins.tokyonight-nvim;
       style = mkOption {
         type = style;
         default = "storm";

--- a/plugins/completion/copilot.nix
+++ b/plugins/completion/copilot.nix
@@ -7,11 +7,7 @@ in
   options = {
     plugins.copilot = {
       enable = mkEnableOption "copilot";
-      package = mkOption {
-        type = types.package;
-        description = "The copilot plugin package to use";
-        default = pkgs.vimPlugins.copilot-vim;
-      };
+      package = helpers.mkPackageOption "copilot" pkgs.vimPlugins.copilot-vim;
       filetypes = mkOption {
         type = types.attrsOf types.bool;
         description = "A dictionary mapping file types to their enabled status";

--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.coq-nvim;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
   plugins = import ../plugin-defs.nix { inherit pkgs; };
 
 in
@@ -11,11 +11,7 @@ in
     plugins.coq-nvim = {
       enable = mkEnableOption "coq-nvim";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.coq-vim;
-        description = "Plugin to use for coq-nvim";
-      };
+      package = helpers.mkPackageOption "coq-nvim" pkgs.vimPlugins.coq-nvim;
 
       installArtifacts = mkEnableOption "Install coq-artifacts";
 

--- a/plugins/completion/lspkind.nix
+++ b/plugins/completion/lspkind.nix
@@ -8,11 +8,7 @@ in
   options.plugins.lspkind = {
     enable = mkEnableOption "lspkind.nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.lspkind-nvim;
-      description = "Plugin to use for lspkind.nvim";
-    };
+    package = helpers.mkPackageOption "lspkind" pkgs.vimPlugins.lspkind-nvim;
 
     mode = mkOption {
       type = with types; nullOr (enum [ "text" "text_symbol" "symbol_text" "symbol" ]);

--- a/plugins/completion/nvim-cmp/cmp-helpers.nix
+++ b/plugins/completion/nvim-cmp/cmp-helpers.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../../helpers.nix { lib = lib; };
+  helpers = import ../../helpers.nix { inherit lib; };
 in with helpers; with lib;
 {
   mkCmpSourcePlugin = { name, extraPlugins ? [], useDefaultPackage ? true, ... }: mkPlugin attrs {

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.nvim-cmp;
-  helpers = import ../../helpers.nix { lib = lib; };
+  helpers = import ../../helpers.nix { inherit lib; };
   mkNullOrOption = helpers.mkNullOrOption;
   cmpLib = import ./cmp-helpers.nix args;
   # functionName should be a string
@@ -17,11 +17,7 @@ in
   options.plugins.nvim-cmp = {
     enable = mkEnableOption "nvim-cmp";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-cmp;
-      description = "Plugin to use for nvim-cmp";
-    };
+    package = helpers.mkPackageOption "nvim-cmp" pkgs.vimPlugins.nvim-cmp;
 
     performance = mkOption {
       default = null;

--- a/plugins/git/fugitive.nix
+++ b/plugins/git/fugitive.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "fugitive";

--- a/plugins/git/gitgutter.nix
+++ b/plugins/git/gitgutter.nix
@@ -9,11 +9,7 @@ in
     plugins.gitgutter = {
       enable = mkEnableOption "gitgutter";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.gitgutter;
-        description = "Plugin to use for gitgutter";
-      };
+      package = helpers.mkPackageOption "gitgutter" pkgs.vimPlugins.gitgutter;
 
       recommendedSettings = mkOption {
         type = types.bool;

--- a/plugins/git/gitsigns.nix
+++ b/plugins/git/gitsigns.nix
@@ -44,11 +44,7 @@ in
 {
   options.plugins.gitsigns = {
     enable = mkEnableOption "Enable gitsigns plugin";
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.gitsigns-nvim;
-      description = "Plugin to use for gitsigns";
-    };
+    package = helpers.mkPackageOption "gitsigns" pkgs.vimPlugins.gitsigns-nvim;
     signs = {
       add = signOptions {
         hl = "GitSignsAdd";

--- a/plugins/git/neogit.nix
+++ b/plugins/git/neogit.nix
@@ -18,11 +18,7 @@ in
     plugins.neogit = {
       enable = mkEnableOption "neogit";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.neogit;
-        description = "Plugin to use for neogit";
-      };
+      package = helpers.mkPackageOption "neogit" pkgs.vimPlugins.neogit;
 
       disableSigns = mkOption {
         description = "Disable signs";

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -1,2 +1,1 @@
 args: import ../lib/helpers.nix args
-

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -1,5 +1,5 @@
 { pkgs, lib, ... }@args:
-with lib; with import ../helpers.nix { lib = lib; };
+with lib; with import ../helpers.nix { inherit lib; };
 mkPlugin args {
   name = "ledger";
   description = "Enable ledger language features";

--- a/plugins/languages/nix.nix
+++ b/plugins/languages/nix.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "nix";

--- a/plugins/languages/plantuml-syntax.nix
+++ b/plugins/languages/plantuml-syntax.nix
@@ -7,11 +7,7 @@ with lib; {
   options.plugins.plantuml-syntax = {
     enable = mkEnableOption "plantuml syntax support";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.plantuml-syntax;
-      description = "Plugin to use for plantuml-syntax";
-    };
+    package = helpers.mkPackageOption "plantuml-syntax" pkgs.vimPlugins.plantuml-syntax;
 
     setMakeprg = mkOption {
       type = types.bool;

--- a/plugins/languages/rust.nix
+++ b/plugins/languages/rust.nix
@@ -46,11 +46,7 @@ with lib; {
     in
     {
       enable = mkEnableOption "rust tools plugins";
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.rust-tools-nvim;
-        description = "Package to use for rust-tools";
-      };
+      package = helpers.mkPackageOption "rust-tools" pkgs.vimPlugins.rust-tools-nvim;
       serverPackage = mkOption {
         type = types.package;
         default = pkgs.rust-analyzer;

--- a/plugins/languages/treesitter-context.nix
+++ b/plugins/languages/treesitter-context.nix
@@ -1,17 +1,14 @@
 { pkgs
 , lib
 , config
+, helpers
 , ...
 }:
 with lib; {
   options.plugins.treesitter-context = {
     enable = mkEnableOption "nvim-treesitter-context";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-treesitter-context;
-      description = "Plugin to use for nvim-treesitter-context";
-    };
+    package = helpers.mkPackageOption "treesitter-context" pkgs.vimPlugins.nvim-treesitter-context;
 
     maxLines = mkOption {
       type = types.nullOr types.ints.positive;

--- a/plugins/languages/treesitter-refactor.nix
+++ b/plugins/languages/treesitter-refactor.nix
@@ -3,7 +3,11 @@
 , lib
 , ...
 }:
-with lib; {
+with lib;
+let
+  helpers = import ../helpers.nix { inherit lib; };
+in
+{
   options.plugins.treesitter-refactor =
     let
       disable = mkOption {
@@ -17,11 +21,7 @@ with lib; {
         mkEnableOption
           "treesitter-refactor (requires plugins.treesitter.enable to be true)";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.nvim-treesitter-refactor;
-        description = "Plugin to use for treesitter-refactor";
-      };
+      package = helpers.mkPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
 
       highlightDefinitions = {
         inherit disable;

--- a/plugins/languages/zig.nix
+++ b/plugins/languages/zig.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "zig";

--- a/plugins/nvim-lsp/lsp-lines.nix
+++ b/plugins/nvim-lsp/lsp-lines.nix
@@ -2,18 +2,14 @@
 with lib;
 let
   cfg = config.plugins.lsp-lines;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options = {
     plugins.lsp-lines = {
       enable = mkEnableOption "lsp_lines.nvim";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.lsp_lines-nvim;
-        description = "Plugin to use for lsp_lines.nvim";
-      };
+      package = helpers.mkPackageOption "lsp_lines.nvim" pkgs.vimPlugins.lsp_lines-nvim;
 
       currentLine = mkOption {
         type = types.bool;

--- a/plugins/nvim-lsp/lspsaga.nix
+++ b/plugins/nvim-lsp/lspsaga.nix
@@ -2,18 +2,14 @@
 with lib;
 let
   cfg = config.plugins.lspsaga;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options = {
     plugins.lspsaga = {
       enable = mkEnableOption "lspsaga.nvim";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.lspsaga-nvim;
-        description = "Plugin to use for lspsaga.nvim";
-      };
+      package = helpers.mkPackageOption "lspsaga" pkgs.vimPlugins.lspsaga-nvim;
 
       signs = {
         use = mkOption {

--- a/plugins/nvim-lsp/nvim-lightbulb.nix
+++ b/plugins/nvim-lsp/nvim-lightbulb.nix
@@ -10,11 +10,7 @@ with lib; {
   options.plugins.nvim-lightbulb = {
     enable = mkEnableOption "nvim-lightbulb, showing available code actions";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-lightbulb;
-      description = "Plugin to use for nvim-lightbulb";
-    };
+    package = helpers.mkPackageOption "nvim-lightbulb" pkgs.vimPlugins.nvim-lightbulb;
 
     ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
       LSP client names to ignore

--- a/plugins/nvim-lsp/trouble.nix
+++ b/plugins/nvim-lsp/trouble.nix
@@ -9,11 +9,7 @@ with lib;
   options.plugins.trouble = {
     enable = mkEnableOption "trouble.nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.trouble-nvim;
-      description = "Plugin to use for trouble-nvim";
-    };
+    package = helpers.mkPackageOption "trouble-nvim" pkgs.vimPlugins.trouble-nvim;
 
     position = helpers.mkNullOrOption (types.enum [ "top" "left" "right" "bottom" ]) "Position of the list";
     height = helpers.mkNullOrOption types.int "Height of the trouble list when position is top or bottom";

--- a/plugins/pluginmanagers/packer.nix
+++ b/plugins/pluginmanagers/packer.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.packer;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options = {

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -2,17 +2,13 @@
 with lib;
 let
   cfg = config.plugins.luasnip;
-  helpers = import ../../helpers.nix { lib = lib; };
+  helpers = import ../../helpers.nix { inherit lib; };
 in
 {
   options.plugins.luasnip = {
     enable = mkEnableOption "Enable luasnip";
 
-    package = mkOption {
-      default = pkgs.vimPlugins.luasnip;
-      type = types.package;
-      description = "Plugin to use for luasnip";
-    };
+    package = helpers.mkPackageOption "luasnip" pkgs.vimPlugins.luasnip;
 
     fromVscode = mkOption {
       default = [ ];

--- a/plugins/statuslines/airline.nix
+++ b/plugins/statuslines/airline.nix
@@ -16,11 +16,7 @@ in
     plugins.airline = {
       enable = mkEnableOption "airline";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.vim-airline;
-        description = "Plguin to use for airline";
-      };
+      package = helpers.mkPackageOption "airline" pkgs.vimPlugins.vim-airline;
 
       extensions = mkOption {
         default = null;

--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -9,11 +9,7 @@ in
     plugins.lightline = {
       enable = mkEnableOption "lightline";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.lightline-vim;
-        description = "Plugin to use for lightline";
-      };
+      package = helpers.mkPackageOption "lightline" pkgs.vimPlugins.lightline-vim;
 
       colorscheme = mkOption {
         type = with types; nullOr str;

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.lualine;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
   separators = mkOption {
     type = types.nullOr (types.submodule {
       options = {
@@ -58,11 +58,7 @@ in
     plugins.lualine = {
       enable = mkEnableOption "lualine";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.lualine-nvim;
-        description = "Plugin to use for lualine";
-      };
+      package = helpers.mkPackageOption "lualine" pkgs.vimPlugins.lualine-nvim;
 
       theme = mkOption {
         default = config.colorscheme;

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -1,8 +1,12 @@
-{ pkgs, config, lib, ... }:
+{ pkgs
+, config
+, lib
+, helpers
+, ...
+}:
 with lib;
 let
   cfg = config.plugins.telescope;
-  helpers = (import ../helpers.nix { inherit lib; });
 in
 {
   imports = [
@@ -18,11 +22,7 @@ in
   options.plugins.telescope = {
     enable = mkEnableOption "telescope.nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.telescope-nvim;
-      description = "Plugin to use for telescope.nvim";
-    };
+    package = helpers.mkPackageOption "telescope.nvim" pkgs.vimPlugins.telescope-nvim;
 
     highlightTheme = mkOption {
       type = types.nullOr types.str;

--- a/plugins/telescope/frecency.nix
+++ b/plugins/telescope/frecency.nix
@@ -7,11 +7,7 @@ in
   options.plugins.telescope.extensions.frecency = {
     enable = mkEnableOption "frecency";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.telescope-frecency-nvim;
-      description = "Plugin to use for telescope frecency";
-    };
+    package = helpers.mkPackageOption "telescope extension frecency" pkgs.vimPlugins.telescope-frecency-nvim;
 
     dbRoot = mkOption {
       type = types.nullOr types.str;

--- a/plugins/telescope/fzf-native.nix
+++ b/plugins/telescope/fzf-native.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, helpers, ... }:
 with lib;
 let
   cfg = config.plugins.telescope.extensions.fzf-native;
@@ -7,11 +7,7 @@ in
   options.plugins.telescope.extensions.fzf-native = {
     enable = mkEnableOption "Enable fzf-native";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.telescope-fzf-native-nvim;
-      description = "Plugin to use for telescope extension fzf-native";
-    };
+    package = helpers.mkPackageOption "telescope extension fzf-native" pkgs.vimPlugins.telescope-fzf-native-nvim;
 
     fuzzy = mkOption {
       type = types.nullOr types.bool;

--- a/plugins/telescope/media-files.nix
+++ b/plugins/telescope/media-files.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, helpers, ... }:
 with lib;
 let
   cfg = config.plugins.telescope.extensions.media_files;
@@ -7,11 +7,7 @@ in
   options.plugins.telescope.extensions.media_files = {
     enable = mkEnableOption "Enable media_files extension for telescope";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.telescope-media-files-nvim;
-      description = "Plugin to use for telescope extension media_files";
-    };
+    package = helpers.mkPackageOption "telescope extension media_files" pkgs.plugins.telescope-media-files-nvim;
 
     filetypes = mkOption {
       default = null;

--- a/plugins/utils/comment-nvim.nix
+++ b/plugins/utils/comment-nvim.nix
@@ -9,11 +9,7 @@ in
     plugins.comment-nvim = {
       enable = mkEnableOption "Enable comment-nvim";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.comment-nvim;
-        description = "Plugin to use for comment-nvim";
-      };
+      package = helpers.mkPackageOption "comment-nvim" pkgs.vimPlugins.comment-nvim;
 
       padding = mkOption {
         type = types.nullOr types.bool;

--- a/plugins/utils/commentary.nix
+++ b/plugins/utils/commentary.nix
@@ -2,6 +2,7 @@
 with lib;
 let
   cfg = config.plugins.commentary;
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   # TODO Add support for aditional filetypes. This requires autocommands!
@@ -10,11 +11,7 @@ in
     plugins.commentary = {
       enable = mkEnableOption "commentary";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.vim-commentary;
-        description = "Plugin to use for vim-commentary";
-      };
+      package = helpers.mkPackageOption "commentary" pkgs.vimPlugins.vim-commentary;
     };
   };
 

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -10,11 +10,7 @@ in
     plugins.dashboard = {
       enable = mkEnableOption "dashboard";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.dashboard-nvim;
-        description = "Plugin to use for dashboard-nvim";
-      };
+      package = helpers.mkPackageOption "dashboard" pkgs.vimPlugins.dashboard-nvim;
 
       header = mkOption {
         description = "Header text";

--- a/plugins/utils/easyescape.nix
+++ b/plugins/utils/easyescape.nix
@@ -9,11 +9,7 @@ in
     plugins.easyescape = {
       enable = mkEnableOption "Enable easyescape";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.vim-easyescape;
-        description = "Plugin to use for easyescape";
-      };
+      package = helpers.mkPackageOption "easyescape" pkgs.vimPlugins.vim-easyescape;
     };
   };
   config = mkIf cfg.enable {

--- a/plugins/utils/endwise.nix
+++ b/plugins/utils/endwise.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "endwise";

--- a/plugins/utils/floaterm.nix
+++ b/plugins/utils/floaterm.nix
@@ -9,11 +9,7 @@ in
     plugins.floaterm = {
       enable = mkEnableOption "floaterm";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.vim-floaterm;
-        description = "Plugin to use for floatterm";
-      };
+      package = helpers.mkPackageOption "floaterm" pkgs.vimPlugins.vim-floaterm;
 
       shell = mkOption {
         type = types.nullOr types.str;

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "goyo";

--- a/plugins/utils/intellitab.nix
+++ b/plugins/utils/intellitab.nix
@@ -9,11 +9,7 @@ in
     plugins.intellitab = {
       enable = mkEnableOption "intellitab.nvim";
 
-      package = mkOption {
-        type = types.package;
-        default = defs.intellitab-nvim;
-        description = "Plugin to use for intellitab.nvim";
-      };
+      package = helpers.mkPackageOption "intellitab.nvim" pkgs.vimPlugins.intellitab-nvim;
     };
   };
 

--- a/plugins/utils/mark-radar.nix
+++ b/plugins/utils/mark-radar.nix
@@ -10,11 +10,7 @@ in
   options.plugins.mark-radar = {
     enable = mkEnableOption "mark-radar";
 
-    package = mkOption {
-      type = types.package;
-      default = defs.mark-radar;
-      description = "Plugin to use for mark-radar";
-    };
+    package = helpers.mkPackageOption "mark-radar" pkgs.vimPlugins.mark-radar;
 
     highlight_background = mkOption {
       type = with types; nullOr bool;

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.notify;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
   icon = mkOption {
     type = types.nullOr types.str;
     default = null;
@@ -12,11 +12,7 @@ in
   options.plugins.notify = {
     enable = mkEnableOption "notify";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-notify;
-      description = "Plugin to use for notify";
-    };
+    package = helpers.mkPackageOption "notify" pkgs.vimPlugins.nvim-notify;
 
     stages = mkOption {
       type = types.nullOr (types.enum [ "fade_in_slide_out" "fade" "slide" "static" ]);

--- a/plugins/utils/nvim-autopairs.nix
+++ b/plugins/utils/nvim-autopairs.nix
@@ -2,17 +2,13 @@
 with lib;
 let
   cfg = config.plugins.nvim-autopairs;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in
 {
   options.plugins.nvim-autopairs = {
     enable = mkEnableOption "nvim-autopairs";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-autopairs;
-      description = "Plugin to use for nvim-autopairs";
-    };
+    package = helpers.mkPackageOption "nvim-autopairs" pkgs.vimPlugins.nvim-autopairs;
 
     pairs = mkOption {
       type = types.nullOr (types.attrsOf types.str);

--- a/plugins/utils/nvim-colorizer.nix
+++ b/plugins/utils/nvim-colorizer.nix
@@ -92,11 +92,7 @@ in
 
       enable = mkEnableOption "nvim-colorizer";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.nvim-colorizer-lua;
-        description = "Plugin to use for vim-commentary";
-      };
+      package = helpers.mkPackageOption "nvim-colorizer" pkgs.vimPlugins.nvim-colorizer-lua;
 
       fileTypes = mkOption {
         description = "Enable and/or configure highlighting for certain filetypes";

--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.plugins.nvim-tree;
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
   optionWarnings = import ../../lib/option-warnings.nix args;
   basePluginPath = [ "plugins" "nvim-tree" ];
 in
@@ -21,11 +21,7 @@ in
   options.plugins.nvim-tree = {
     enable = mkEnableOption "nvim-tree";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.nvim-tree-lua;
-      description = "Plugin to use for nvim-tree";
-    };
+    package = helpers.mkPackageOption "nvim-tree" pkgs.vimPlugins.nvim-tree-lua;
 
     disableNetrw = mkOption {
       type = types.nullOr types.bool;

--- a/plugins/utils/project-nvim.nix
+++ b/plugins/utils/project-nvim.nix
@@ -2,17 +2,13 @@
 with lib;
 let
   cfg = config.plugins.project-nvim;
-  helpers = import ../helpers.nix { inherit lib; };
+  helpers = import ../helpers.nix { inherit lib pkgs; };
 in
 {
   options.plugins.project-nvim = helpers.extraOptionsOptions // {
     enable = mkEnableOption "project.nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.project-nvim;
-      description = "Plugin to use for project-nvim";
-    };
+    package = helpers.mkPackageOption "project-nvim" pkgs.vimPlugins.projecy-nvim;
 
     manualMode = mkOption {
       type = types.nullOr types.bool;

--- a/plugins/utils/specs.nix
+++ b/plugins/utils/specs.nix
@@ -8,11 +8,7 @@ in
   options.plugins.specs = {
     enable = mkEnableOption "specs-nvim";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.specs-nvim;
-      description = "Plugin to use for specs-nvim";
-    };
+    package = helpers.mkPackageOption "specs-nvim" pkgs.vimPlugins.specs-nvim;
 
     show_jumps = mkOption {
       type = types.bool;

--- a/plugins/utils/startify.nix
+++ b/plugins/utils/startify.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }@args:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with lib; with helpers;
 mkPlugin args {
   name = "startify";

--- a/plugins/utils/surround.nix
+++ b/plugins/utils/surround.nix
@@ -1,6 +1,6 @@
 { lib, pkgs, ... }@attrs:
 let
-  helpers = import ../helpers.nix { lib = lib; };
+  helpers = import ../helpers.nix { inherit lib; };
 in with helpers; with lib;
 mkPlugin attrs {
   name = "surround";

--- a/plugins/utils/undotree.nix
+++ b/plugins/utils/undotree.nix
@@ -9,11 +9,7 @@ in
     plugins.undotree = {
       enable = mkEnableOption "Enable undotree";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vimPlugins.undotree;
-        description = "Plugin to use for undotree";
-      };
+      package = helpers.mkPackageOption "undotree" pkgs.vimPlugins.undotree;
 
       windowLayout = mkOption {
         type = types.nullOr types.int;


### PR DESCRIPTION
This PR adds a new helper function: `mkPackageOption`.

It replaces:
```nix
package = mkOption {
  type = types.package;
  default = pkgs.vimPlugins.gruvbox-nvim;
  description = "Plugin to use for gruvbox";
};
```

with:
```nix
package = helpers.mkPackageOption "gruvbox" "gruvbox-nvim";
```

It required me to add  `pkgs` as an input of `helpers.nix`... For me it is worth it. What do you think ?