### PR TITLE
nvim-lsp: added nvim-cmp completion capabilities

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -453,6 +453,14 @@ in {
           })
           known_source_names);
       in
-        mkIf cfg.auto_enable_sources attrs_enabled;
+        mkMerge [
+          (mkIf cfg.auto_enable_sources attrs_enabled)
+          (mkIf (elem "nvim_lsp" found_sources)
+            {
+              lsp.capabilities = ''
+                capabilities = require('cmp_nvim_lsp').default_capabilities()
+              '';
+            })
+        ];
     };
 }

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -21,6 +21,7 @@
     ./git/gitmessenger.nix
     ./git/gitsigns.nix
     ./git/neogit.nix
+
     ./languages/clangd-extensions.nix
     ./languages/ledger.nix
     ./languages/markdown-preview.nix


### PR DESCRIPTION
As the [`nvim-cmp` documentation states](https://github.com/hrsh7th/nvim-cmp#recommended-configuration), the LSP servers need to be made aware of the lsp capabilities:

```lua
-- Set up lspconfig.
local capabilities = require('cmp_nvim_lsp').default_capabilities()
-- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
require('lspconfig')['<YOUR_LSP_SERVER>'].setup {
  capabilities = capabilities
}
```

This PR automatically injects this lua code when the `cmp-nvim-lsp` plugin is enabled.