### PR TITLE
plugins/utils/nvim-tree: marked setup options as deprecated

### DIFF
--- a/plugins/utils/nvim-tree.nix
+++ b/plugins/utils/nvim-tree.nix
@@ -16,6 +16,14 @@ in
       option = basePluginPath ++ [ "updateFocusedFile" "updateCwd" ];
       newOption = basePluginPath ++ [ "updateFocusedFile" "updateRoot" ];
     })
+    (optionWarnings.mkDeprecatedOption {
+      option = basePluginPath ++ [ "openOnSetup" ];
+      alternative = [];
+    })
+    (optionWarnings.mkDeprecatedOption {
+      option = basePluginPath ++ [ "ignoreFtOnSetup" ];
+      alternative = [];
+    })
   ];
 
   options.plugins.nvim-tree = {
@@ -35,12 +43,14 @@ in
       description = "Hijack netrw";
     };
 
+    # deprecated
     openOnSetup = mkOption {
       type = types.nullOr types.bool;
       default = null;
       description = "Open on setup";
     };
 
+    # deprecated
     ignoreFtOnSetup = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;


### PR DESCRIPTION
Some nvim-tree options have been deprecated.
See: https://github.com/nvim-tree/nvim-tree.lua/wiki/Open-At-Startup#legacy-migration
This PR marks them as deprecated.

In the wiki, they suggest implementations that a user could put in his config to replicate these behaviors.
Maybe we could implement them and restore the corresponding options later.
This is not the goal of this PR.