### PR TITLE
plugins/utils/indent-blankline: fix enable option

### DIFF
--- a/plugins/utils/indent-blankline.nix
+++ b/plugins/utils/indent-blankline.nix
@@ -8,7 +8,7 @@ with lib; let
 in
 {
   options.plugins.indent-blankline = {
-    enable = helpers.defaultNullOpts.mkBool false "Enable indent-blankline.nvim";
+    enable = mkEnableOption "indent-blankline.nvim";
 
     package = helpers.mkPackageOption "indent-blankline" pkgs.vimPlugins.indent-blankline-nvim;
 


### PR DESCRIPTION
The `enable` option of the indent-blankline plugin was wrongly implemented which was causing a bug when building any nixvim configuration:
```
error: ‘mkIf’ called with a non-Boolean condition
```

The bug was introduced in https://github.com/pta2002/nixvim/commit/89bf2d660b6696b7548214e22f74d343397c9d4e.