### PR TITLE
Fixed vuels dependency

### DIFF
--- a/plugins/nvim-lsp/basic-servers.nix
+++ b/plugins/nvim-lsp/basic-servers.nix
@@ -230,7 +230,7 @@ let
     {
       name = "vuels";
       description = "Enable vuels, for Vue";
-      package = pkgs.nodePackages.vue-language-server;
+      package = pkgs.nodePackages.vls;
     }
     {
       name = "zls";


### PR DESCRIPTION
I think we changed this a while back, but this should be correct.

When looking at search.nixos.org for vls [link to search for vls](https://search.nixos.org/packages?channel=22.11&from=0&size=50&sort=relevance&type=packages&query=vls) and [link to search for vue-language-server](https://search.nixos.org/packages?channel=22.11&from=0&size=50&sort=relevance&type=packages&query=vue-language-server), the homepage link is the same, but versions are different.
Looking at [npm for vls](https://www.npmjs.com/package/vls) we can see the version matches with the vls package.