### PR TITLE
plugins/completion/coq.nix: Enable coq_settings.xdg by default

### DIFF
--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -33,6 +33,7 @@ in
       settings = {
         auto_start = cfg.autoStart;
         "keymap.recommended" = cfg.recommendedKeymaps;
+        xdg = true;
       };
     in
     mkIf cfg.enable {


### PR DESCRIPTION
Without `coq_settings.xdg`, `:COQdeps` attempts to install dependencies into the nix store and fails for obvious permission reasons.