### PR TITLE
modules/options: use vim.opt instead of vim.o

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -35,7 +35,7 @@ in
         local nixvim_options = ${helpers.toLuaObject config.options}
 
         for k,v in pairs(nixvim_options) do
-          vim.o[k] = v
+          vim.opt[k] = v
         end
       end
       -- }}}


### PR DESCRIPTION
By setting the options on `vim.opt` instead of `vim.o` we are able to use table values (dictionaries/lists) when specifying options.