### PR TITLE
modules/autocmd: autoCmd.callback: support raw value

### DIFF
--- a/modules/autocmd.nix
+++ b/modules/autocmd.nix
@@ -30,22 +30,42 @@ with lib; let
         Pattern or patterns to match literally against.
       '';
 
-      buffer = helpers.defaultNullOpts.mkInt "" ''
+      buffer = helpers.mkNullOrOption types.int ''
         Buffer number for buffer local autocommands |autocmd-buflocal|.
-        Cannot be used with <pattern>.
+        Cannot be used with `pattern`.
       '';
 
-      description = helpers.defaultNullOpts.mkStr "" "A textual description of this autocommand.";
+      description = helpers.mkNullOrOption types.str "A textual description of this autocommand.";
 
-      callback = helpers.defaultNullOpts.mkStr "" ''
-        The name of a Vimscript function to call when this autocommand is triggered. Cannot be used with <command>.
+      callback = helpers.mkNullOrOption (types.either types.str helpers.rawType) ''
+        A function or a string.
+        - if a string, the name of a Vimscript function to call when this autocommand is triggered.
+        - Otherwise, a Lua function which is called when this autocommand is triggered.
+          Cannot be used with `command`.
+          Lua callbacks can return true to delete the autocommand; in addition, they accept a single
+          table argument with the following keys:
+          - id: (number) the autocommand id
+          - event: (string) the name of the event that triggered the autocommand |autocmd-events|
+          - group: (number|nil) the autocommand group id, if it exists
+          - match: (string) the expanded value of |<amatch>|
+          - buf: (number) the expanded value of |<abuf>|
+          - file: (string) the expanded value of |<afile>|
+          - data: (any) arbitrary data passed to |nvim_exec_autocmds()|
+
+        Example using callback:
+        autoCmd = [
+          {
+            event = [ "BufEnter" "BufWinEnter" ];
+            pattern = [ "*.c" "*.h" ];
+            callback = { __raw = "function() print("This buffer enters") end"; };
+          }
       '';
 
       command = helpers.defaultNullOpts.mkStr "" ''
-        Vim command to execute on event. Cannot be used with <callback>
+        Vim command to execute on event. Cannot be used with `callback`.
       '';
 
-      once = helpers.defaultNullOpts.mkBool false "Run the autocommand only once";
+      once = helpers.defaultNullOpts.mkBool false "Run the autocommand only once.";
 
       nested = helpers.defaultNullOpts.mkBool false "Run nested autocommands.";
     };
@@ -81,41 +101,44 @@ in {
     };
   };
 
-  config = mkIf (config.autoGroups != {} || config.autoCmd != {}) {
-    extraConfigLuaPost =
-      (optionalString (config.autoGroups != {}) ''
-        -- Set up autogroups {{
-        do
-          local __nixvim_autogroups = ${helpers.toLuaObject config.autoGroups}
+  config = let
+    inherit (config) autoGroups autoCmd;
+  in
+    mkIf (autoGroups != {} || autoCmd != {}) {
+      extraConfigLuaPost =
+        (optionalString (autoGroups != {}) ''
+          -- Set up autogroups {{
+          do
+            local __nixvim_autogroups = ${helpers.toLuaObject autoGroups}
 
-          for group_name, options in pairs(__nixvim_autogroups) do
-            vim.api.nvim_create_augroup(group_name, options)
+            for group_name, options in pairs(__nixvim_autogroups) do
+              vim.api.nvim_create_augroup(group_name, options)
+            end
           end
-        end
-        -- }}
-      '')
-      + (optionalString (config.autoCmd != []) ''
-        -- Set up autocommands {{
-        do
-          local __nixvim_autocommands = ${helpers.toLuaObject config.autoCmd}
+          -- }}
+        '')
+        + (optionalString (autoCmd != []) ''
+          -- Set up autocommands {{
+          do
+            local __nixvim_autocommands = ${helpers.toLuaObject autoCmd}
 
-          for _, autocmd in ipairs(__nixvim_autocommands) do
-            vim.api.nvim_create_autocmd(
-              autocmd.event,
-              {
-                group     = autocmd.group,
-                pattern   = autocmd.pattern,
-                buffer    = autocmd.buffer,
-                desc      = autocmd.desc,
-                callback  = autocmd.callback,
-                command   = autocmd.command,
-                once      = autocmd.once,
-                nested    = autocmd.nested
-              }
-            )
+            for _, autocmd in ipairs(__nixvim_autocommands) do
+              vim.api.nvim_create_autocmd(
+                autocmd.event,
+                {
+                  group     = autocmd.group,
+                  pattern   = autocmd.pattern,
+                  buffer    = autocmd.buffer,
+                  desc      = autocmd.desc,
+                  callback  = autocmd.callback,
+                  command   = autocmd.command,
+                  once      = autocmd.once,
+                  nested    = autocmd.nested
+                }
+              )
+            end
           end
-        end
-        -- }}
-      '');
-  };
+          -- }}
+        '');
+    };
 }


### PR DESCRIPTION
The `callback` option in `nvim_create_autocmd()` can be either a string or a lua function.
The previous implementation of the `autoCmd` module did not support the latest.
This PR changes the type of this option from `str` to either `str` or `rawType`.