### PR TITLE
plugins/languages/treesitter: add pkgs.gcc in extraPackages

### DIFF
--- a/plugins/languages/treesitter.nix
+++ b/plugins/languages/treesitter.nix
@@ -152,7 +152,7 @@ in {
         if cfg.nixGrammars
         then [(cfg.package.withPlugins (_: cfg.grammarPackages))]
         else [cfg.package];
-      extraPackages = [pkgs.tree-sitter pkgs.nodejs];
+      extraPackages = [pkgs.tree-sitter pkgs.nodejs pkgs.gcc];
 
       options = mkIf cfg.folding {
         foldmethod = "expr";


### PR DESCRIPTION
`:checkhealth` for `treesitter` complains that no compiler is available.
Hence, I added `pkgs.gcc` in the dependencies.