### PR TITLE
plugins/nvim-lsp: add the pylsp server

### DIFF
--- a/plugins/nvim-lsp/basic-servers.nix
+++ b/plugins/nvim-lsp/basic-servers.nix
@@ -199,6 +199,11 @@ with lib; let
       settings = cfg: {nil = {inherit (cfg) formatting diagnostics;};};
     }
     {
+      name = "pylsp";
+      description = "Enable pylsp, for Python.";
+      package = pkgs.python3Packages.python-lsp-server;
+    }
+    {
       name = "pyright";
       description = "Enable pyright, for Python.";
     }


### PR DESCRIPTION
Add the [`pylsp`](https://github.com/python-lsp/python-lsp-server)  for python.