### PR TITLE
modules/keymaps: bind lua function calls

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -55,7 +55,13 @@ with lib; rec {
           nowait = false;
           action = action;
         }
-        else action)
+        else {
+          inherit (action) silent expr unique noremap script nowait;
+          action =
+            if action.lua
+            then mkRaw action.action
+            else action;
+        })
       maps;
   in
     builtins.attrValues (builtins.mapAttrs

--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -51,11 +51,18 @@ with lib; let
           description = "The action to execute.";
         };
 
-        description = mkOption {
-          type = types.nullOr types.str;
-          description = "A textual description of this keybind, to be shown in which-key, if you have it.";
-          default = null;
+        lua = mkOption {
+          type = types.bool;
+          description = ''
+            If true, `action` is considered to be lua code.
+            Thus, it will not be wrapped in `""`.
+          '';
+          default = false;
         };
+
+        description = helpers.mkNullOrOption types.str ''
+          A textual description of this keybind, to be shown in which-key, if you have it.
+        '';
       };
     })
   ];


### PR DESCRIPTION
Right now, it is not possible to bind a raw lua function to a key.
Well, it is possible by doing this:
```nix
maps.normal.x = ":lua my_lua_func()<cr>";
```
which is not very pleasant.

This PR adds a new field to the action submodule for mappings. The example above would become:
```nix
maps.normal.x.luaFunc = "my_lua_func";
```