### PR TITLE
plugins/completion/nvim-cmp: add extraOptions option for the cmp-tabnine plugin

### DIFF
--- a/plugins/completion/nvim-cmp/sources/cmp-tabnine.nix
+++ b/plugins/completion/nvim-cmp/sources/cmp-tabnine.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.cmp-tabnine;
+  helpers = import ../../../helpers.nix {inherit lib;};
+in {
+  options.plugins.cmp-tabnine = helpers.extraOptionsOptions;
+
+  config = mkIf cfg.enable {
+    extraConfigLua = ''
+      require('cmp_tabnine.config'):setup(${helpers.toLuaObject cfg.extraOptions})
+    '';
+  };
+}

--- a/plugins/completion/nvim-cmp/sources/default.nix
+++ b/plugins/completion/nvim-cmp/sources/default.nix
@@ -11,6 +11,7 @@ in {
   # For extra cmp plugins
   imports =
     [
+      ./cmp-tabnine.nix
     ]
     ++ pluginModules;
 }


### PR DESCRIPTION
This allows the user to provide options to the setup function of `cmp-tabnine`.