### PR TITLE
plugins/nvim-lsp: added options for lua_ls

### DIFF
--- a/plugins/nvim-lsp/language-servers/default.nix
+++ b/plugins/nvim-lsp/language-servers/default.nix
@@ -5,7 +5,8 @@
   ...
 } @ args:
 with lib; let
-  helpers = import ../helpers.nix args;
+  lspHelpers = import ../helpers.nix args;
+  helpers = import ../../helpers.nix {inherit lib;};
 
   optionWarnings = import ../../../lib/option-warnings.nix args;
   basePluginPath = ["plugins" "lsp" "servers"];
@@ -225,6 +226,58 @@ with lib; let
       description = "Enable lua LS, for lua";
       package = pkgs.lua-language-server;
       serverName = "lua_ls";
+
+      # All available settings are documented here:
+      # https://github.com/LuaLS/lua-language-server/wiki/Settings
+      settingsOptions = {
+        runtime = {
+          version = mkOption {
+            type = types.nullOr types.str;
+            description = ''
+              Tell the language server which version of Lua you're using
+              (most likely LuaJIT in the case of Neovim)
+            '';
+            default = "LuaJIT";
+          };
+        };
+        diagnostics = {
+          globals = mkOption {
+            type = types.nullOr (types.listOf types.str);
+            description = ''
+              An array of variable names that will be declared as global.
+            '';
+            default = ["vim"];
+          };
+        };
+        workspace = {
+          library = mkOption {
+            type = types.nullOr (types.either types.str (helpers.rawType));
+            description = ''
+              An array of abosolute or workspace-relative paths that will be added to the workspace
+              diagnosis - meaning you will get completion and context from these library files.
+              Can be a file or directory.
+              Files included here will have some features disabled such as renaming fields to
+              prevent accidentally renaming your library files.
+            '';
+            default = helpers.mkRaw "vim.api.nvim_get_runtime_file('', true)";
+          };
+          checkThirdParty = mkOption {
+            type = types.nullOr types.bool;
+            description = ''
+              Whether third party libraries can be automatically detected and applied.
+              Third party libraries can set up the environment to be as close as possible to your
+              target runtime environment.
+            '';
+            # prevents an annoying warning
+            # https://github.com/LuaLS/lua-language-server/discussions/1688#discussioncomment-4185003
+            default = false;
+          };
+        };
+        telemetry = {
+          enable = mkEnableOption "telemetry";
+        };
+      };
+      settings = cfg: {Lua = cfg;};
     }
     {
       name = "tailwindcss";
@@ -258,7 +311,7 @@ with lib; let
   ];
 in {
   imports =
-    lib.lists.map (helpers.mkLsp) servers
+    lib.lists.map (lspHelpers.mkLsp) servers
     ++ [
       (optionWarnings.mkRenamedOption {
         option = basePluginPath ++ ["sumneko-lua"];


### PR DESCRIPTION
Added the most useful options for `lua_ls` and initialized the defaults as recommended by the [`nvim-lsp` documentation](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#lua_ls).