### PR TITLE
modules/keymaps: fix bug in keymaps generation

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -60,7 +60,7 @@ with lib; rec {
           action =
             if action.lua
             then mkRaw action.action
-            else action;
+            else action.action;
         })
       maps;
   in


### PR DESCRIPTION
A bug was introduced in https://github.com/pta2002/nixvim/pull/178.
This PR fixes it.