### PR TITLE
plugins/ledger: correct enable option description

### DIFF
--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -7,7 +7,7 @@ with lib;
 with import ../helpers.nix {inherit lib;};
   mkPlugin args {
     name = "ledger";
-    description = "Enable ledger language features";
+    description = "ledger language features";
     package = pkgs.vimPlugins.vim-ledger;
 
     options = {


### PR DESCRIPTION
The `enabled` option description was wrongly specified.