### PR TITLE
plugins/nvim-lsp/pylsp: fix bug in settings generation

### DIFF
--- a/plugins/nvim-lsp/language-servers/default.nix
+++ b/plugins/nvim-lsp/language-servers/default.nix
@@ -267,6 +267,7 @@ with lib; let
       name = "pylsp";
       description = "Enable pylsp, for Python.";
       package = pkgs.python3Packages.python-lsp-server;
+      settings = cfg: {pylsp = cfg;};
     }
     {
       name = "pyright";


### PR DESCRIPTION
I forgot to set the settings generation function option which led the pylsp settings declared in `pylsp.nix` ignored.