### PR TITLE
plugins/statuslines/lualine: fix type of color option

### DIFF
--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -45,7 +45,7 @@ with lib; let
 
           separator = mkSeparatorsOption {name = "Component";};
 
-          color = helpers.mkNullOrOption (with types; either str (attrsOf str)) ''
+          color = helpers.mkNullOrOption (types.attrsOf types.str) ''
             Defines a custom color for the component.
           '';
 


### PR DESCRIPTION
While refactoring I mis-defined the type of option `color` for the components.
`str or (attrsOf str)` --> `attrsOf str`