### PR TITLE
plugins/nvim-lsp: Add a user option to set the cmd of each language server

### DIFF
--- a/plugins/nvim-lsp/helpers.nix
+++ b/plugins/nvim-lsp/helpers.nix
@@ -39,6 +39,10 @@
         plugins.lsp.servers.${name} =
           {
             enable = mkEnableOption description;
+            cmd = mkOption {
+              type = with types; nullOr (listOf str);
+              default = cmd cfg;
+            };
             settings = settingsOptions;
             extraSettings = mkOption {
               default = {};
@@ -62,7 +66,7 @@
             {
               name = serverName;
               extraOptions = {
-                cmd = cmd cfg;
+                cmd = cfg.cmd;
                 settings = settings (cfg.settings // cfg.extraSettings);
               };
             }


### PR DESCRIPTION
This is a proposal to implement the `plugins.lsp.servers.<name>.cmd` option.
This lets the user provide a custom command to run the language servers.
For some language servers, nixvim sets a default value for it. For others, it is left to `null`.