### PR TITLE
plugins/nvim-lsp: add a fallback for the lua LS package

### DIFF
--- a/plugins/nvim-lsp/language-servers/default.nix
+++ b/plugins/nvim-lsp/language-servers/default.nix
@@ -172,7 +172,12 @@ with lib; let
     {
       name = "lua-ls";
       description = "Enable lua LS, for lua";
-      package = pkgs.lua-language-server;
+      # Use the old name of the lua LS if the user is on a stable branch of nixpkgs
+      # Rename occured here: https://github.com/NixOS/nixpkgs/pull/215057
+      package =
+        if (hasAttr "lua-language-server" pkgs)
+        then pkgs.lua-language-server
+        else pkgs.sumneko-lua-language-server;
       serverName = "lua_ls";
 
       # All available settings are documented here:


### PR DESCRIPTION
The lua language server package has been renamed [in nixpkgs](https://github.com/NixOS/nixpkgs/pull/215057) and thus also [in nixvim](https://github.com/pta2002/nixvim/pull/169).
However, the users following a stable version of nixpkgs should be using the old name.
Now, nixvim should be robust to both stable/unstable state of nixpkgs.