### PR TITLE
helpers: fix toLuaObject ignoring empty objects

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -20,7 +20,7 @@ with lib; rec {
               if head (stringToCharacters n) == "@"
               then toLuaObject v
               else "[${toLuaObject n}] = " + (toLuaObject v))
-            (filterAttrs (n: v: !isNull v && toLuaObject v != "{}") args)))
+            (filterAttrs (n: v: !isNull v) args)))
         + "}"
     else if builtins.isList args
     then "{" + concatMapStringsSep "," toLuaObject args + "}"


### PR DESCRIPTION
At the moment, toLuaObject ignores empty objects, leading to some settings like `neorg`'s modules not working