### PR TITLE
plugins/vimtex: fix VimtexInverseSearch

### DIFF
--- a/plugins/languages/vimtex.nix
+++ b/plugins/languages/vimtex.nix
@@ -26,6 +26,7 @@ in
       globals =
         {
           enabled = cfg.enable;
+          callback_progpath = "nvim";
         }
         // cfg.extraConfig;
     in


### PR DESCRIPTION
## Vimtex inverse search
The vimtex plugin ofter an _inverse search_ feature.
The principle is that you can click somewhere in your pdf preview document, and your cursor within vim will move to the corresponding latex line.
To make this work, vimtex runs the PDF viewer with the following command line:
```
zathura  -x "PATH_TO_NVIM --headless -c \"VimtexInverseSearch %{line} '%{input}'\"" --synctex-forward 1:1:'PATH_TO_TEX_FILE' 'PATH_TO_PDF_PREVIEW_FILE'&
```
So what happens, is when you click somewhere in the document within the PDF viewer, the latter runs a headless vim instance that calls `VimtexInverseSearch` with the corresponding line.

## The problem
What happens in our case is that `PATH_TO_NVIM`  is the path to the nvim binary. When running this binary directly, none of the installed plugins are loaded.
What happens when you type `nvim` in your shell, it runs a wrapper script which makes sur `nvim` is called with the right plugin paths.
Hence, the current behavior is a crash of this headless `nvim` session run by the PDF viewer. Something like `Not an editor command: VimtexInverseSearch`.

## The solution
The value for `PATH_TO_NVIM` can be set manually by setting the vim global variable `g:vimtex_callback_progpath`.
This PR sets it simply to `nvim`, which is resolved to the valid wrapper script.
--> IT WORKS !

Another approach would have been to set it to the derivation output of nixvim directly.
I was not sure on how to reference the module output within itself.
This has been discussed here: https://discourse.nixos.org/t/accessing-flake-outputs-in-the-flake-itself/14662/2.