### PR TITLE
plugins/bufferline: fix typo in 'error_diagnostic'

### DIFF
--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -340,7 +340,7 @@ in {
             error_visible = errorVisible;
             error_selected = errorSelected;
 
-            error_dagnostic = errorDiagnostic;
+            error_diagnostic = errorDiagnostic;
             error_diagnostic_visible = errorDiagnosticVisible;
             error_diagnostic_selected = errorDiagnosticSelected;
 


### PR DESCRIPTION
Changes `error_dagnostic` to `error_diagnostic` for bufferline.nvim, to prevent Bufferline from not recognizing the option of `error_dagnostic`.