### PR TITLE
Added flake template

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ for a home-manager installation, `inputs.nixvim.nixosModules.nixvim`, for NixOS,
 and `inputs.nixvim.nixDarwinModules.nixvim` for nix-darwin.
 
 ## Usage
-NixVim can be used in four ways: through the home-manager, nix-darwin, and NixOS modules,
-and through the `makeNixvim` function. To use the modules, just import the
+NixVim can be used in four ways: through the home-manager, nix-darwin, NixOS modules,
+and standalone through the `makeNixvim` function. To use the modules, just import the
 `nixvim.homeManagerModules.nixvim`, `nixvim.nixDarwinModules.nixvim`, and
 `nixvim.nixosModules.nixvim` modules, depending on which system
 you're using.
@@ -100,8 +100,17 @@ If you want to use it standalone, you can use the `makeNixvim` function:
 }
 ```
 
+To get started with a standalone configuration you can use the template by running the following command in an empty directory (recommended):
+
+```
+nix flake init --template github:pta2002/nixvim
+```
+
 Alternatively if you want a minimal flake to allow building a custom neovim you
 can use the following:
+
+<details>
+  <summary>Minimal flake configuration</summary>
 
 ```nix
 {
@@ -131,6 +140,8 @@ can use the following:
     });
 }
 ```
+
+</details>
 
 You can then run neovim using `nix run .# -- <file>`. This can be useful to test
 config changes easily.

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,11 @@
               };
           };
           formatter = pkgs.alejandra;
+
+          lib = import ./lib {
+            inherit pkgs;
+            inherit (pkgs) lib;
+          };
         });
     in
       flakeOutput
@@ -114,5 +119,14 @@
         nixosModules.nixvim = import ./wrappers/nixos.nix modules;
         homeManagerModules.nixvim = import ./wrappers/hm.nix modules;
         nixDarwinModules.nixvim = import ./wrappers/darwin.nix modules;
+
+        templates = let
+          simple = {
+            path = ./templates/simple;
+            description = "A simple nix flake template for getting started with nixvim";
+          };
+        in {
+          default = simple;
+        };
       };
 }

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -1,0 +1,30 @@
+{pkgs, ...}: {
+  checkNvim = {
+    name,
+    nvim,
+    ...
+  }:
+    pkgs.stdenv.mkDerivation {
+      name = name;
+
+      nativeBuildInputs = [nvim];
+
+      dontUnpack = true;
+      # We need to set HOME because neovim will try to create some files
+      #
+      # Because neovim does not return an exitcode when quitting we need to check if there are
+      # errors on stderr
+      buildPhase = ''
+        output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
+        if [[ -n $output ]]; then
+        	echo "ERROR: $output"
+          exit 1
+        fi
+      '';
+
+      # If we don't do this nix is not happy
+      installPhase = ''
+        mkdir $out
+      '';
+    };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,7 @@
+# Args probably only needs pkgs and lib
+args:
+{
+  # Add all exported modules here
+  check = import ./check.nix args;
+  helpers = import ./helpers.nix args;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,5 @@
 # Args probably only needs pkgs and lib
-args:
-{
+args: {
   # Add all exported modules here
   check = import ./check.nix args;
   helpers = import ./helpers.nix args;

--- a/templates/simple/README.md
+++ b/templates/simple/README.md
@@ -1,0 +1,16 @@
+# Nixvim template
+
+This template gives you a good starting point for configuring nixvim standalone.
+
+## Configuring
+
+To start configuring, just add or modify the nix files in `./config`. If you add a new configuration file, remember to add it to the [`congig/default.nix`](./config/default.nix) file
+
+## Testing your new configuration
+
+To test your configuration simply run the following command
+
+```
+nix run .
+```
+

--- a/templates/simple/config/bufferline.nix
+++ b/templates/simple/config/bufferline.nix
@@ -1,0 +1,5 @@
+{
+  plugins.bufferline = {
+    enable = true;
+  };
+}

--- a/templates/simple/config/default.nix
+++ b/templates/simple/config/default.nix
@@ -1,0 +1,6 @@
+{
+  # Import all your configuration modules here
+  imports = [
+    ./bufferline.nix
+  ];
+}

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -2,8 +2,7 @@
   description = "A nixvim configuration";
 
   inputs = {
-    # nixvim.url = "github:pta2002/nixvim";
-    nixvim.url = "path:../..";
+    nixvim.url = "github:pta2002/nixvim";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -17,7 +16,7 @@
     config = import ./config; # import the module directly
   in
     flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs { inherit system; };
       nixvim' = nixvim.legacyPackages.${system};
       nvim = nixvim'.makeNixvimWithModule {
         inherit pkgs;

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -16,7 +16,7 @@
     config = import ./config; # import the module directly
   in
     flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs { inherit system; };
+      pkgs = import nixpkgs {inherit system;};
       nixvim' = nixvim.legacyPackages.${system};
       nvim = nixvim'.makeNixvimWithModule {
         inherit pkgs;

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "A nixvim configuration";
+
+  inputs = {
+    # nixvim.url = "github:pta2002/nixvim";
+    nixvim.url = "path:../..";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    nixvim,
+    flake-utils,
+    ...
+  } @ inputs: let
+    nixvimLib = nixvim.lib;
+    config = import ./config; # import the module directly
+  in
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      nixvim' = nixvim.legacyPackages.${system};
+      nvim = nixvim'.makeNixvimWithModule {
+        inherit pkgs;
+        module = config;
+      };
+    in {
+      checks = {
+        # Run `nix check .` to verify that your config is not broken
+        default = nixvim.lib.${system}.check.checkNvim {
+          inherit nvim;
+          name = "A nixvim configuration";
+        };
+      };
+
+      packages = {
+        # Lets you run `nix run .` to start nixvim
+        default = nvim;
+      };
+    });
+}

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -1,36 +1,16 @@
 {
   makeNixvim,
   pkgs,
-}: let
+} @ args: let
   tests = import ./plugins {inherit (pkgs) lib;};
+  check = import ../lib/check.nix args;
+  checkConfig = check.checkNvim;
 in
   # We attempt to build & execute all configurations
   builtins.mapAttrs (
     name: config: let
       nvim = makeNixvim config;
     in
-      pkgs.stdenv.mkDerivation {
-        name = name;
-
-        nativeBuildInputs = [nvim];
-
-        dontUnpack = true;
-        # We need to set HOME because neovim will try to create some files
-        #
-        # Because neovim does not return an exitcode when quitting we need to check if there are
-        # errors on stderr
-        buildPhase = ''
-          output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
-          if [[ -n $output ]]; then
-          	echo "ERROR: $output"
-            exit 1
-          fi
-        '';
-
-        # If we don't do this nix is not happy
-        installPhase = ''
-          mkdir $out
-        '';
-      }
+      checkConfig { inherit name nvim; }
   )
   tests

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -11,6 +11,6 @@ in
     name: config: let
       nvim = makeNixvim config;
     in
-      checkConfig { inherit name nvim; }
+      checkConfig {inherit name nvim;}
   )
   tests


### PR DESCRIPTION
I have added a flake template, which I think can be beneficial for new Nixvim users and users who do not yet use standalone.

I have also exposed some of the lib in the flake. This allows the template to use the check function defined in lib.
Another benefit of exposing lib is that it might be more intuitive to use the helpers this way, compared to the current one where you need to access `config.nixvim.helpers`, instead you can use `inputs.nixvim.lib.helpers`.