### PR TITLE
helpers: add mkCompositeOption

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -85,6 +85,9 @@ with lib; rec {
 
   mkIfNonNull = c: mkIf (!isNull c) c;
 
+  mkCompositeOptions = desc: options:
+    mkNullOrOption (types.submodule {inherit options;}) desc;
+
   defaultNullOpts = rec {
     mkNullable = type: default: desc:
       mkNullOrOption type (


### PR DESCRIPTION
We often need to create nested options.
Most of the time, it is done like this:
```nix
parentOption = {
  subOption1 = ...;
  subOption2 = ...;
  ...
};
```
This has two problems:

1. It is not possible to provide a description for the parent option.
2. When the user sets non of the child options, the parent option has value `{}` [which is ambiguous to translate to lua in this case](https://github.com/pta2002/nixvim/pull/213).

The alternative is using the following syntax:
```nix
parentOption = helpers.mkNullOrOption
  (types.submodule {
    options = {
      subOption1 = ...;
      subOption2= ...;
      ...
    };
  })
  DESCRIPTION
;
```

This fixes both of the previous issues. However, it is more verbose and annoying to write.

Hence, this PR introduces a wrapper that leads to the following syntax:
```nix
parentOption = helpers.mkCompositeOption {
    subOption1 = ...;
    subOption2 = ...;
    ...
  }
  DESCRIPTION
;
```