### PR TITLE
gitignore: add .direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tmp
 result
 .pre-commit-config.yaml
+.direnv


### PR DESCRIPTION
The direnv integration was introduced in #220.
Using it requires to create a `.direnv` directory which is currently not ignored by git.