### PR TITLE
helpers: typo (mkCompositeOptions -> mkCompositeOption)

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -85,7 +85,7 @@ with lib; rec {
 
   mkIfNonNull = c: mkIf (!isNull c) c;
 
-  mkCompositeOptions = desc: options:
+  mkCompositeOption = desc: options:
     mkNullOrOption (types.submodule {inherit options;}) desc;
 
   defaultNullOpts = rec {


### PR DESCRIPTION
Oops, typo.