### PR TITLE
pugins/nvim-cmp: fix the completion.autocomplete option

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -382,7 +382,7 @@ in {
           autocomplete =
             if (isNull cfg.completion.autocomplete)
             then null
-            else mkRaw cfg.completion.autocomplete;
+            else helpers.mkRaw cfg.completion.autocomplete;
           completeopt = cfg.completion.completeopt;
         };
 


### PR DESCRIPTION
Adds missing `helpers.` in a `helpers.mkRaw` utilisation.