### PR TITLE
bugfix: Set default for `programs.nixvim`.

### DIFF
--- a/modules/colorscheme.nix
+++ b/modules/colorscheme.nix
@@ -12,8 +12,8 @@ with lib; {
     };
   };
 
-  config = {
-    extraConfigVim = optionalString (config.colorscheme != "" && config.colorscheme != null) ''
+  config = mkIf (config.colorscheme != "" && config.colorscheme != null) {
+    extraConfigVim = ''
       colorscheme ${config.colorscheme}
     '';
   };

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -10,6 +10,7 @@ modules: {
 in {
   options = {
     programs.nixvim = mkOption {
+      default = {};
       type = types.submodule ((modules pkgs)
         ++ [
           {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -10,6 +10,7 @@ modules: {
 in {
   options = {
     programs.nixvim = mkOption {
+      default = {};
       type = types.submodule ((modules pkgs)
         ++ [
           {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -10,6 +10,7 @@ modules: {
 in {
   options = {
     programs.nixvim = mkOption {
+      default = {};
       type = types.submodule ((modules pkgs)
         ++ [
           {


### PR DESCRIPTION
fixes #224

setting a default for the nixvim submodule, makes it possible to build with no options set.