### PR TITLE
lib/helpers: fix typo in mkModeMaps

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -101,7 +101,7 @@ with lib; rec {
         actionAttrs =
           if isString action
           then {inherit action;}
-          else value;
+          else action;
       in
         defaults // actionAttrs
     )


### PR DESCRIPTION
Fix typo in `mkModeMaps`