### PR TITLE
plugins/todo-comments: fix missing mkRaw for pattern options

### DIFF
--- a/tests/plugins/todo-comments.nix
+++ b/tests/plugins/todo-comments.nix
@@ -62,7 +62,7 @@
         before = "";
         keyword = "wide";
         after = "fg";
-        pattern = "[[.*<(KEYWORDS)\s*:]]";
+        pattern = ''.*<(KEYWORDS)\s*:'';
         commentsOnly = true;
         maxLineLen = 400;
         exclude = [];
@@ -86,7 +86,7 @@
           "--line-number"
           "--column"
         ];
-        pattern = "[[\b(KEYWORDS):]]";
+        pattern = ''\b(KEYWORDS):'';
       };
 
       keymapsSilent = true;


### PR DESCRIPTION
The `highlight.pattern` and `search.pattern` options were not exported as pure lua code.
Added `mkRaw` to fix this.