### PR TITLE
plugins/nvim-cmp: add enum type for option snippet.expand

### DIFF
--- a/tests/plugins/nvim-cmp.nix
+++ b/tests/plugins/nvim-cmp.nix
@@ -4,6 +4,13 @@
     plugins.nvim-cmp.enable = true;
   };
 
+  snippetEngine = {
+    plugins.nvim-cmp = {
+      enable = true;
+      snippet.expand = "luasnip";
+    };
+  };
+
   # All the upstream default options of nvim-cmp
   defaults = {
     plugins.nvim-cmp = {
@@ -18,7 +25,7 @@
       preselect = "Item";
 
       snippet = {
-        expand = ''
+        expand.__raw = ''
           function(_)
             error('snippet engine is not configured.')
           end


### PR DESCRIPTION
Add an enum type for the `snippet.expand` option which sets the underlying option with the relevant function.

Before:
```nix
snippet.expand = ''
  function(args)
    require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
   end
'';
```

After:
```nix
snippet.expand = "luasnip";
```