### PR TITLE
Enable creation of other config files than init.lua

### DIFF
--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,10 +1,18 @@
-{
+modules: {
   lib,
   pkgs,
+  config,
   ...
 }: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
 in {
+  topLevelModules =
+    [
+      ./modules/output.nix
+      (import ./modules/files.nix (modules pkgs))
+    ]
+    ++ (modules pkgs);
+
   helpers = mkOption {
     type = mkOptionType {
       name = "helpers";
@@ -14,4 +22,16 @@ in {
     description = "Use this option to access the helpers";
     default = import ../plugins/helpers.nix {inherit (pkgs) lib;};
   };
+
+  configFiles = let
+    cfg = config.programs.nixvim;
+  in
+    lib.mapAttrs'
+    (
+      _: file:
+        lib.nameValuePair
+        "nvim/${file.path}"
+        {text = file.content;}
+    )
+    cfg.files;
 }

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -5,19 +5,19 @@ modules: {
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
-  shared = import ./_shared.nix args;
+  shared = import ./_shared.nix modules args;
   cfg = config.programs.nixvim;
 in {
   options = {
     programs.nixvim = mkOption {
       default = {};
-      type = types.submodule ((modules pkgs)
-        ++ [
+      type = types.submodule ([
           {
             options.enable = mkEnableOption "nixvim";
             config.wrapRc = mkForce true;
           }
-        ]);
+        ]
+        ++ shared.topLevelModules);
     };
     nixvim.helpers = shared.helpers;
   };

--- a/wrappers/modules/files.nix
+++ b/wrappers/modules/files.nix
@@ -1,0 +1,64 @@
+modules: {
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) types;
+  fileModuleType = types.submodule ({
+    name,
+    config,
+    ...
+  }: {
+    imports = modules;
+    options.plugin = lib.mkOption {
+      type = types.package;
+      description = "A derivation with the content of the file in it";
+      readOnly = true;
+      internal = true;
+    };
+    config = {
+      path = name;
+      type = lib.mkDefault (
+        if lib.hasSuffix ".vim" name
+        then "vim"
+        else "lua"
+      );
+      plugin = pkgs.writeTextDir config.path config.content;
+    };
+  });
+in {
+  options = {
+    files = lib.mkOption {
+      type = types.attrsOf fileModuleType;
+      description = "Files to include in the vim config";
+      default = {};
+    };
+
+    filesPlugin = lib.mkOption {
+      type = types.package;
+      description = "A derivation with all the files inside";
+      internal = true;
+      readOnly = true;
+    };
+  };
+
+  config = let
+    files = config.files;
+    concatFilesOption = attr:
+      lib.flatten (lib.mapAttrsToList (_: file: builtins.getAttr attr file) files);
+  in {
+    # Each file can declare plugins/packages/warnings/assertions
+    extraPlugins = concatFilesOption "extraPlugins";
+    extraPackages = concatFilesOption "extraPackages";
+    warnings = concatFilesOption "warnings";
+    assertions = concatFilesOption "assertions";
+
+    # A directory with all the files in it
+    filesPlugin = pkgs.buildEnv {
+      name = "nixvim-config";
+      paths = lib.mapAttrsToList (_: file: file.plugin) files;
+      ignoreCollisions = true; # Collisions can't happen by construction
+    };
+  };
+}

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -1,0 +1,134 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  pluginWithConfigType = types.submodule {
+    options = {
+      config = mkOption {
+        type = types.lines;
+        description = "vimscript for this plugin to be placed in init.vim";
+        default = "";
+      };
+
+      optional =
+        mkEnableOption "optional"
+        // {
+          description = "Don't load by default (load with :packadd)";
+        };
+
+      plugin = mkOption {
+        type = types.package;
+        description = "vim plugin";
+      };
+    };
+  };
+in {
+  options = {
+    viAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Symlink <command>vi</command> to <command>nvim</command> binary.
+      '';
+    };
+
+    vimAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Symlink <command>vim</command> to <command>nvim</command> binary.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.neovim-unwrapped;
+      description = "Neovim to use for nixvim";
+    };
+
+    wrapRc = mkOption {
+      type = types.bool;
+      description = "Should the config be included in the wrapper script";
+      default = false;
+    };
+
+    finalPackage = mkOption {
+      type = types.package;
+      description = "Wrapped neovim";
+      readOnly = true;
+    };
+
+    initContent = mkOption {
+      type = types.str;
+      description = "The content of the init.lua file";
+      readOnly = true;
+      visible = false;
+    };
+  };
+
+  config = let
+    defaultPlugin = {
+      plugin = null;
+      config = "";
+      optional = false;
+    };
+
+    normalizedPlugins = map (x:
+      defaultPlugin
+      // (
+        if x ? plugin
+        then x
+        else {plugin = x;}
+      ))
+    config.extraPlugins;
+
+    neovimConfig = pkgs.neovimUtils.makeNeovimConfig ({
+        inherit (config) viAlias vimAlias;
+        # inherit customRC;
+        plugins = normalizedPlugins;
+      }
+      # Necessary to make sure the runtime path is set properly in NixOS 22.05,
+      # or more generally before the commit:
+      # cda1f8ae468 - neovim: pass packpath via the wrapper
+      // optionalAttrs (functionArgs pkgs.neovimUtils.makeNeovimConfig ? configure) {
+        configure.packages = {
+          nixvim = {
+            start = map (x: x.plugin) normalizedPlugins;
+            opt = [];
+          };
+        };
+      });
+
+    customRC =
+      ''
+        vim.cmd([[
+          ${neovimConfig.neovimRcContent}
+        ]])
+      ''
+      + config.content;
+
+    extraWrapperArgs = builtins.concatStringsSep " " (
+      (optional (config.extraPackages != [])
+        ''--prefix PATH : "${makeBinPath config.extraPackages}"'')
+      ++ (optional (config.wrapRc)
+        ''--add-flags -u --add-flags "${pkgs.writeText "init.lua" customRC}"'')
+    );
+
+    wrappedNeovim = pkgs.wrapNeovimUnstable config.package (neovimConfig
+      // {
+        wrapperArgs = lib.escapeShellArgs neovimConfig.wrapperArgs + " " + extraWrapperArgs;
+        wrapRc = false;
+      });
+  in {
+    type = lib.mkForce "lua";
+    finalPackage = wrappedNeovim;
+    initContent = customRC;
+    extraPlugins =
+      if config.wrapRc
+      then [config.filesPlugin]
+      else [];
+  };
+}

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -5,18 +5,23 @@ modules: {
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkMerge mkIf types;
-  shared = import ./_shared.nix args;
+  shared = import ./_shared.nix modules args;
   cfg = config.programs.nixvim;
+  files =
+    shared.configFiles
+    // {
+      "nvim/sysinit.lua".text = cfg.initContent;
+    };
 in {
   options = {
     programs.nixvim = mkOption {
       default = {};
-      type = types.submodule ((modules pkgs)
-        ++ [
+      type = types.submodule ([
           {
             options.enable = mkEnableOption "nixvim";
           }
-        ]);
+        ]
+        ++ shared.topLevelModules);
     };
     nixvim.helpers = shared.helpers;
   };
@@ -26,7 +31,7 @@ in {
     (mkMerge [
       {environment.systemPackages = [cfg.finalPackage];}
       (mkIf (!cfg.wrapRc) {
-        environment.etc."nvim/sysinit.lua".text = cfg.initContent;
+        environment.etc = files;
         environment.variables."VIM" = "/etc/nvim";
       })
       {

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -6,8 +6,13 @@ default_pkgs: modules: {
 
   wrap = {wrapRc = true;};
 
+  shared = import ./_shared.nix modules {
+    inherit pkgs lib;
+    config = {};
+  };
+
   eval = lib.evalModules {
-    modules = (modules pkgs) ++ [module wrap];
+    modules = [module wrap] ++ shared.topLevelModules;
   };
 
   handleAssertions = config: let


### PR DESCRIPTION
This is an attempt at solving #49 . It separates options into file-level (ie options that add to a file), and global options (that controls how nvim is instantiated). All plugins are file-level options. Using file-level options at the top-level adds to `init.lua`, but those options can also be used in `files.*` to create other files in the config. For example, one could do:
```nix
{
  programs.nixvim = {
    files."ftdetect/myft.lua".autoCmd = [
      {
        event = [ "BufRead" "BufNewFile" ];
        pattern = [ "*.myft" ];
        command = "set ft=myft";
      }
    ];
  };
}
```

By using options in `ftplugin/ft.lua` files, it allows setting options only in for some filetypes. Furthermore, it supports generating both lua and vim files (and guess which one to use depending on the extension of the file).

Notes:
- It should be backward compatible.
- I haven't included the top-level options in the docs. It shouldn't be too hard, but if I do that almost all options will appear twice, once at the top level and once in `files.*`, which may be problematic.
- I haven't tested the nixos module yet, but the home-manager one seems to work, both in wrapped and unwrapped mode.