### PR TITLE
neo-tree: Allow other plugins to insert their sources

### DIFF
--- a/plugins/utils/neo-tree.nix
+++ b/plugins/utils/neo-tree.nix
@@ -40,6 +40,10 @@ in {
           The name used here must be the same name you would use in a require() call.
         '';
 
+      extraSources = helpers.mkNullOrOption (types.listOf types.str) ''
+        Extra sources to be added to the sources. This is an internal nixvim option.
+      '';
+
       addBlankLineAtTop =
         helpers.defaultNullOpts.mkBool false
         "Add a blank line at the top of the tree.";
@@ -945,7 +949,15 @@ in {
 
     options = with cfg;
       {
-        inherit (cfg) sources;
+        # Concatenate sources and extraSources, setting sources to it's default value if it is null
+        # and extraSources is not null
+        sources =
+          if (!isNull cfg.extraSources)
+          then
+            if (isNull cfg.sources)
+            then ["filesystem" "git_status" "buffers"] ++ cfg.extraSources
+            else cfg.sources ++ cfg.extraSources
+          else cfg.sources;
         add_blank_line_at_top = cfg.addBlankLineAtTop;
         auto_clean_after_session_restore = cfg.autoCleanAfterSessionRestore;
         close_if_last_window = cfg.closeIfLastWindow;


### PR DESCRIPTION
Some plugins define neo-tree sources. For theese plugins having an option 'neoTreeIntegration = true' would be useful. The problem is that if we set the plugins.neo-tree.sources to ["<source>"] then we ditch the default values of ["filesystem" ...]. The idea here is to define an internal extraSources option that takes care of the following:

- If sources is null set it to the default sources
- Concatenate sources and extraSources