### PR TITLE
helpers/keymap: fix noremap bug

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -51,6 +51,7 @@ with lib; rec {
           expr = false;
           unique = false;
           noremap = true;
+          remap = false;
           script = false;
           nowait = false;
           action = action;


### PR DESCRIPTION
Fix bug introduced in https://github.com/pta2002/nixvim/pull/256.