### PR TITLE
tests: Allow to skip running neovim

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -2,6 +2,7 @@
   checkNvim = {
     name,
     nvim,
+    dontRun,
     ...
   }:
     pkgs.stdenv.mkDerivation {
@@ -14,13 +15,17 @@
       #
       # Because neovim does not return an exitcode when quitting we need to check if there are
       # errors on stderr
-      buildPhase = ''
-        output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
-        if [[ -n $output ]]; then
-        	echo "ERROR: $output"
-          exit 1
-        fi
-      '';
+      buildPhase =
+        if !dontRun
+        then ''
+          output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
+          if [[ -n $output ]]; then
+          	echo "ERROR: $output"
+            exit 1
+          fi
+        ''
+        else ''
+        '';
 
       # If we don't do this nix is not happy
       installPhase = ''

--- a/tests/checks.nix
+++ b/tests/checks.nix
@@ -9,8 +9,17 @@ in
   # We attempt to build & execute all configurations
   builtins.mapAttrs (
     name: config: let
-      nvim = makeNixvim config;
+      testAttributes =
+        if builtins.hasAttr "tests" config
+        then config.tests
+        else {
+          dontRun = false;
+        };
+      nvim = makeNixvim (pkgs.lib.attrsets.filterAttrs (n: _: n != "tests") config);
     in
-      checkConfig {inherit name nvim;}
+      checkConfig {
+        inherit name nvim;
+        inherit (testAttributes) dontRun;
+      }
   )
   tests


### PR DESCRIPTION
Some plugins don't really play nicely with being launched in a headless sandboxed environment. This adds the pseudo option 'tests.dontRun' to avoid running those tests