### PR TITLE
plugins/nvim-osc52: init + tests

### DIFF
--- a/plugins/_sources/generated.json
+++ b/plugins/_sources/generated.json
@@ -99,6 +99,26 @@
         },
         "version": "d7fb84a670795a5b36b18a5b59afd1d3865cbec7"
     },
+    "nvim-osc52": {
+        "cargoLocks": null,
+        "date": "2023-03-03",
+        "extract": null,
+        "name": "nvim-osc52",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "ojroques",
+            "repo": "nvim-osc52",
+            "rev": "47ce7ee2396fa3ee4fb6b0e0ef14ba06f9c9bd31",
+            "sha256": "sha256-SQpwiA+dyTRXBq0YtUZ4nkYKglyChIyQeWopD73qznQ=",
+            "type": "github"
+        },
+        "version": "47ce7ee2396fa3ee4fb6b0e0ef14ba06f9c9bd31"
+    },
     "pynvim_pp": {
         "cargoLocks": null,
         "date": "2023-03-12",

--- a/plugins/_sources/generated.nix
+++ b/plugins/_sources/generated.nix
@@ -61,6 +61,18 @@
     });
     date = "2021-06-22";
   };
+  nvim-osc52 = {
+    pname = "nvim-osc52";
+    version = "47ce7ee2396fa3ee4fb6b0e0ef14ba06f9c9bd31";
+    src = fetchFromGitHub ({
+      owner = "ojroques";
+      repo = "nvim-osc52";
+      rev = "47ce7ee2396fa3ee4fb6b0e0ef14ba06f9c9bd31";
+      fetchSubmodules = false;
+      sha256 = "sha256-SQpwiA+dyTRXBq0YtUZ4nkYKglyChIyQeWopD73qznQ=";
+    });
+    date = "2023-03-03";
+  };
   pynvim_pp = {
     pname = "pynvim_pp";
     version = "40db0426f171d413dcc976b17c8eff0127664f23";

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -70,6 +70,7 @@
     ./utils/nvim-bqf.nix
     ./utils/nvim-colorizer.nix
     ./utils/nvim-tree.nix
+    ./utils/nvim-osc52.nix
     ./utils/project-nvim.nix
     ./utils/specs.nix
     ./utils/startify.nix

--- a/plugins/nvfetcher.toml
+++ b/plugins/nvfetcher.toml
@@ -25,3 +25,7 @@ fetch.github = "ms-jpq/coq.artifacts"
 [magma-nvim]
 src.git = "https://github.com/WhiteBlackGoose/magma-nvim-goose"
 fetch.github = "WhiteBlackGoose/magma-nvim-goose"
+
+[nvim-osc52]
+src.git = "https://github.com/ojroques/nvim-osc52"
+fetch.github = "ojroques/nvim-osc52"

--- a/plugins/plugin-defs.nix
+++ b/plugins/plugin-defs.nix
@@ -70,4 +70,8 @@ in {
         })
       ];
   };
+
+  nvim-osc52 = pkgs.vimUtils.buildVimPlugin {
+    inherit (sources.nvim-osc52) pname version src;
+  };
 }

--- a/plugins/utils/nvim-osc52.nix
+++ b/plugins/utils/nvim-osc52.nix
@@ -1,0 +1,85 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+} @ args: let
+  plugin-defs = import ../plugin-defs.nix {inherit pkgs;};
+  helpers = import ../helpers.nix args;
+in
+  with lib; {
+    options.plugins.nvim-osc52 = {
+      enable = mkEnableOption "nvim-osc52, a plugin to use OSC52 sequences to copy/paste";
+      package = helpers.mkPackageOption "nvim-osc52" plugin-defs.nvim-osc52;
+
+      maxLength =
+        helpers.defaultNullOpts.mkInt 0 "Maximum length of selection (0 for no limit)";
+      silent = helpers.defaultNullOpts.mkBool false "Disable message on successful copy";
+      trim = helpers.defaultNullOpts.mkBool false "Trim text before copy";
+
+      keymaps = {
+        enable = mkEnableOption "keymaps for copying using OSC52";
+        silent = mkOption {
+          type = types.bool;
+          description = "Wether nvim-osc52 keymaps should be silent";
+          default = false;
+        };
+
+        copy = mkOption {
+          type = types.str;
+          description = "Copy into the system clipboard using OSC52";
+          default = "<leader>y";
+        };
+
+        copyLine = mkOption {
+          type = types.str;
+          description = "Copy line into the system clipboard using OSC52";
+          default = "<leader>yy";
+        };
+
+        copyVisual = mkOption {
+          type = types.str;
+          description = "Copy visual selection into the system clipboard using OSC52";
+          default = "<leader>y";
+        };
+      };
+    };
+
+    config = let
+      cfg = config.plugins.nvim-osc52;
+      setupOptions = with cfg; {
+        inherit silent trim;
+        max_length = maxLength;
+      };
+    in
+      mkIf cfg.enable {
+        extraPlugins = [cfg.package];
+
+        maps = mkIf cfg.keymaps.enable {
+          normal = {
+            "${cfg.keymaps.copy}" = {
+              action = "require('osc52').copy_operator";
+              expr = true;
+              lua = true;
+              silent = cfg.keymaps.silent;
+            };
+            "${cfg.keymaps.copyLine}" = {
+              action = "${cfg.keymaps.copy}_";
+              remap = true;
+              silent = cfg.keymaps.silent;
+            };
+          };
+          visual = {
+            "${cfg.keymaps.copyVisual}" = {
+              action = "require('osc52').copy_visual";
+              lua = true;
+              silent = cfg.keymaps.silent;
+            };
+          };
+        };
+
+        extraConfigLua = ''
+          require('osc52').setup(${helpers.toLuaObject setupOptions})
+        '';
+      };
+  }

--- a/tests/plugins/nvim-osc52.nix
+++ b/tests/plugins/nvim-osc52.nix
@@ -1,0 +1,18 @@
+{
+  empty = {
+    plugins.nvim-osc52.enable = true;
+  };
+
+  defaults = {
+    plugins.nvim-osc52 = {
+      maxLength = 0;
+      silent = false;
+      trim = false;
+
+      keymaps = {
+        silent = false;
+        enable = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
nvim-osc52 is a plugin that allows to copy from neovim using OSC52 control sequences (works through SSH for example)