### PR TITLE
plugins/inc-rename: init + tests

### DIFF
--- a/plugins/_sources/generated.json
+++ b/plugins/_sources/generated.json
@@ -39,6 +39,26 @@
         },
         "version": "4b4b93dbbfc871a3d32a244a4276ee06696c21bb"
     },
+    "inc-rename": {
+        "cargoLocks": null,
+        "date": "2023-01-29",
+        "extract": null,
+        "name": "inc-rename",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "smjonas",
+            "repo": "inc-rename.nvim",
+            "rev": "21c23c379342a731a0c90f226601ec0434627b26",
+            "sha256": "sha256-KxXVe0amA0tyU6J2M+4XERSyERWS4BqGuxmbJ9YUyRs=",
+            "type": "github"
+        },
+        "version": "21c23c379342a731a0c90f226601ec0434627b26"
+    },
     "intellitab-nvim": {
         "cargoLocks": null,
         "date": "2021-11-13",

--- a/plugins/_sources/generated.nix
+++ b/plugins/_sources/generated.nix
@@ -25,6 +25,18 @@
     });
     date = "2023-03-12";
   };
+  inc-rename = {
+    pname = "inc-rename";
+    version = "21c23c379342a731a0c90f226601ec0434627b26";
+    src = fetchFromGitHub ({
+      owner = "smjonas";
+      repo = "inc-rename.nvim";
+      rev = "21c23c379342a731a0c90f226601ec0434627b26";
+      fetchSubmodules = false;
+      sha256 = "sha256-KxXVe0amA0tyU6J2M+4XERSyERWS4BqGuxmbJ9YUyRs=";
+    });
+    date = "2023-01-29";
+  };
   intellitab-nvim = {
     pname = "intellitab-nvim";
     version = "a6c1a505865f6131866d609c52440306e9914b16";

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -60,6 +60,7 @@
     ./utils/floaterm.nix
     ./utils/goyo.nix
     ./utils/harpoon.nix
+    ./utils/inc-rename.nix
     ./utils/indent-blankline.nix
     ./utils/intellitab.nix
     ./utils/mark-radar.nix

--- a/plugins/nvfetcher.toml
+++ b/plugins/nvfetcher.toml
@@ -33,3 +33,7 @@ fetch.github = "ojroques/nvim-osc52"
 [netman-nvim]
 src.git = "https://github.com/miversen33/netman.nvim"
 fetch.github = "miversen33/netman.nvim"
+
+[inc-rename]
+src.git = "https://github.com/smjonas/inc-rename.nvim"
+fetch.github = "smjonas/inc-rename.nvim"

--- a/plugins/plugin-defs.nix
+++ b/plugins/plugin-defs.nix
@@ -78,4 +78,8 @@ in {
   netman-nvim = pkgs.vimUtils.buildVimPlugin {
     inherit (sources.netman-nvim) pname version src;
   };
+
+  inc-rename = pkgs.vimUtils.buildVimPlugin {
+    inherit (sources.inc-rename) pname version src;
+  };
 }

--- a/plugins/utils/inc-rename.nix
+++ b/plugins/utils/inc-rename.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+} @ args:
+with lib; let
+  helpers = import ../helpers.nix args;
+  plugin-defs = import ../plugin-defs.nix {inherit pkgs;};
+in {
+  options.plugins.inc-rename = {
+    enable = mkEnableOption "inc-rename, a plugin previewing LSP renaming";
+
+    package = helpers.mkPackageOption "inc-rename" plugin-defs.inc-rename;
+
+    cmdName = helpers.defaultNullOpts.mkStr "IncRename" "the name of the command";
+    hlGroup =
+      helpers.defaultNullOpts.mkStr "Substitute"
+      "the highlight group used for highlighting the identifier's new name";
+    previewEmptyName = helpers.defaultNullOpts.mkBool false ''
+      whether an empty new name should be previewed; if false the command preview will be cancelled
+      instead
+    '';
+    showMessage = helpers.defaultNullOpts.mkBool true ''
+      whether to display a `Renamed m instances in n files` message after a rename operation
+    '';
+    inputBufferType = helpers.defaultNullOpts.mkNullable (types.enum ["dressing"]) "null" ''
+      the type of the external input buffer to use
+    '';
+    postHook = helpers.defaultNullOpts.mkNullable types.str "null" ''
+      callback to run after renaming, receives the result table (from LSP handler) as an argument
+    '';
+  };
+
+  config = let
+    cfg = config.plugins.inc-rename;
+    setupOptions = {
+      cmd_name = cfg.cmdName;
+      hl_group = cfg.hlGroup;
+      preview_empty_name = cfg.previewEmptyName;
+      show_message = cfg.showMessage;
+      input_buffer_type = cfg.inputBufferType;
+      post_hook = helpers.ifNonNull' cfg.postHook (helpers.mkRaw cfg.postHook);
+    };
+  in
+    mkIf cfg.enable {
+      extraPlugins = [cfg.package];
+
+      extraConfigLua = ''
+        require("inc_rename").setup(${helpers.toLuaObject setupOptions})
+      '';
+    };
+}

--- a/tests/plugins/inc-rename.nix
+++ b/tests/plugins/inc-rename.nix
@@ -1,0 +1,17 @@
+{
+  empty = {
+    plugins.inc-rename.enable = true;
+  };
+
+  defaults = {
+    plugins.inc-rename = {
+      enable = true;
+      cmdName = "IncRename";
+      hlGroup = "Substitute";
+      previewEmptyName = false;
+      showMessage = true;
+      inputBufferType = null;
+      postHook = null;
+    };
+  };
+}


### PR DESCRIPTION
inc-rename is a plugin that allows to show incrementally an LSP renaming (like %s)