### PR TITLE
tests: Fix netman tests by including docker

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -8,7 +8,7 @@
     pkgs.stdenv.mkDerivation {
       name = name;
 
-      nativeBuildInputs = [nvim];
+      nativeBuildInputs = [nvim pkgs.docker-client];
 
       dontUnpack = true;
       # We need to set HOME because neovim will try to create some files

--- a/tests/plugins/netman.nix
+++ b/tests/plugins/netman.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    tests.dontRun = true;
     plugins.netman.enable = true;
   };
 
   withNeotree = {
-    tests.dontRun = true;
     plugins.neo-tree.enable = true;
     plugins.netman = {
       enable = true;


### PR DESCRIPTION
Netman tries to call 'docker -v' and it hangs neovim if the docker command is not found. This adds the docker binary to the derivation running checks