### PR TITLE
plugin/luasnip: Add jsregexp lua dependency

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -103,6 +103,12 @@ in {
       readOnly = true;
       visible = false;
     };
+
+    extraLuaPackages = mkOption {
+      type = types.functionTo (types.listOf types.package);
+      description = "Extra lua packages to include with neovim";
+      default = _: [];
+    };
   };
 
   config = let
@@ -122,7 +128,7 @@ in {
     config.extraPlugins;
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig ({
-        inherit (config) viAlias vimAlias;
+        inherit (config) viAlias vimAlias extraLuaPackages;
         # inherit customRC;
         plugins = normalizedPlugins;
       }

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -91,6 +91,7 @@ in {
   in
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
+      extraLuaPackages = ps: [ps.jsregexp];
       extraConfigLua = concatStringsSep "\n" fromVscodeLoaders;
     };
 }


### PR DESCRIPTION
The lua dependency is required to perform transforms (luasnip can fallback to a simpler algorithm if it's absent). This requires us to expose the `extraLuaPackages` option of makeNeovimConfig.