### PR TITLE
helpers: add globalPrefix to mkPlugin

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -192,6 +192,7 @@ with lib; rec {
     extraPlugins ? [],
     extraPackages ? [],
     options ? {},
+    globalPrefix ? "",
     ...
   }: let
     cfg = config.plugins.${name};
@@ -200,7 +201,7 @@ with lib; rec {
     globals =
       mapAttrs'
       (name: opt: {
-        name = opt.global;
+        name = globalPrefix + opt.global;
         value =
           if cfg.${name} != null
           then opt.value cfg.${name}

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -10,27 +10,29 @@ with import ../helpers.nix {inherit lib;};
     description = "ledger language features";
     package = pkgs.vimPlugins.vim-ledger;
 
+    globalPrefix = "ledger_";
+
     options = {
       maxWidth = mkDefaultOpt {
-        global = "ledger_maxwidth";
+        global = "maxwidth";
         description = "Number of columns to display foldtext";
         type = types.int;
       };
 
       fillString = mkDefaultOpt {
-        global = "ledger_fillstring";
+        global = "fillstring";
         description = "String used to fill the space between account name and amount in the foldtext";
         type = types.int;
       };
 
       detailedFirst = mkDefaultOpt {
-        global = "ledger_detailed_first";
+        global = "detailed_first";
         description = "Account completion sorted by depth instead of alphabetically";
         type = types.bool;
       };
 
       foldBlanks = mkDefaultOpt {
-        global = "ledger_fold_blanks";
+        global = "fold_blanks";
         description = "Hide blank lines following a transaction on a fold";
         type = types.bool;
       };

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -16,23 +16,24 @@ in
       name = "emmet";
       description = "Enable emmet";
       package = pkgs.vimPlugins.emmet-vim;
+      globalPrefix = "user_emmet_";
 
       options = {
         mode = mkDefaultOpt {
           type = types.enum ["i" "n" "v" "a"];
-          global = "user_emmet_mode";
+          global = "mode";
           description = "Mode where emmet will enable";
         };
 
         leader = mkDefaultOpt {
           type = types.str;
-          global = "user_emmet_leader_key";
+          global = "leader_key";
           description = "Set leader key";
         };
 
         settings = mkDefaultOpt {
           type = types.attrsOf (types.attrsOf eitherAttrsStrInt);
-          global = "user_emmet_settings";
+          global = "settings";
           description = "Emmet settings";
         };
       };

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -11,23 +11,24 @@ in
       name = "goyo";
       description = "Enable goyo.vim";
       package = pkgs.vimPlugins.goyo-vim;
+      globalPrefix = "goyo_";
 
       options = {
         width = mkDefaultOpt {
           description = "Width";
-          global = "goyo_width";
+          global = "width";
           type = types.int;
         };
 
         height = mkDefaultOpt {
           description = "Height";
-          global = "goyo_height";
+          global = "height";
           type = types.int;
         };
 
         showLineNumbers = mkDefaultOpt {
           description = "Show line numbers when in Goyo mode";
-          global = "goyo_linenr";
+          global = "linenr";
           type = types.bool;
         };
       };

--- a/plugins/utils/startify.nix
+++ b/plugins/utils/startify.nix
@@ -11,17 +11,18 @@ in
       name = "startify";
       description = "Enable startify";
       package = pkgs.vimPlugins.vim-startify;
+      globalPrefix = "startify_";
 
       options = {
         sessionDir = mkDefaultOpt {
           description = "Directory to save/load session";
-          global = "startify_session_dir";
+          global = "session_dir";
           type = types.str;
         };
 
         lists = mkDefaultOpt {
           description = "Startify display lists. If it's a string, it'll be interpreted as literal lua code";
-          global = "startify_lists";
+          global = "lists";
           type = types.listOf (types.oneOf [
             (types.submodule {
               options = {
@@ -57,176 +58,176 @@ in
 
         bookmarks = mkDefaultOpt {
           description = "A list of files or directories to bookmark.";
-          global = "startify_bookmarks";
+          global = "bookmarks";
           type = with types; listOf (oneOf [str (attrsOf str)]);
         };
 
         commands = mkDefaultOpt {
           description = "A list of commands to execute on selection";
-          global = "startify_commands";
+          global = "commands";
           type = with types; listOf (oneOf [str (listOf str) attrs]);
         };
 
         filesNumber = mkDefaultOpt {
           description = "The number of files to list";
-          global = "startify_files_number";
+          global = "files_number";
           type = types.int;
         };
 
         updateOldFiles = mkDefaultOpt {
           description = "Update v:oldfiles on-the-fly, so that :Startify is always up-to-date";
-          global = "startify_update_oldfiles";
+          global = "update_oldfiles";
           type = types.bool;
         };
 
         sessionAutoload = mkDefaultOpt {
           description = "Load Session.vim";
-          global = "startify_session_autoload";
+          global = "session_autoload";
           type = types.bool;
         };
 
         sessionBeforeSave = mkDefaultOpt {
           description = "Commands to be executed before saving a session";
-          global = "startify_session_before_save";
+          global = "session_before_save";
           type = types.listOf types.str;
         };
 
         sessionPersistence = mkDefaultOpt {
           description = "Automatically update sessions";
-          global = "startify_session_persistence";
+          global = "session_persistence";
           type = types.bool;
         };
 
         sessionDeleteBuffers = mkDefaultOpt {
           description = "Delete all buffers when loading or closing a session";
-          global = "startify_session_delete_buffers";
+          global = "session_delete_buffers";
           type = types.bool;
         };
 
         changeToDir = mkDefaultOpt {
           description = "When opening a file or bookmark, change to its directory";
-          global = "startify_change_to_dir";
+          global = "change_to_dir";
           type = types.bool;
         };
 
         changeToVcsRoot = mkDefaultOpt {
           description = "When opening a file or bookmark, change to the root directory of the VCS";
-          global = "startify_change_to_vcs_root";
+          global = "change_to_vcs_root";
           type = types.bool;
         };
 
         changeCmd = mkDefaultOpt {
           description = "The default command for switching directories";
-          global = "startify_change_cmd";
+          global = "change_cmd";
           type = types.enum ["cd" "lcd" "tcd"];
         };
 
         skipList = mkDefaultOpt {
           description = "A list of regexes that is used to filter recently used files";
-          global = "startify_skiplist";
+          global = "skiplist";
           type = types.listOf types.str;
         };
 
         useUnicode = mkDefaultOpt {
           description = "Use unicode box drawing characters for the fortune header";
-          global = "startify_fortune_use_unicode";
+          global = "fortune_use_unicode";
           type = types.bool;
         };
 
         paddingLeft = mkDefaultOpt {
           description = "Number of spaces used for left padding";
-          global = "startify_padding_left";
+          global = "padding_left";
           type = types.int;
         };
 
         skipListServer = mkDefaultOpt {
           description = "Do not create the startify buffer if this is a Vim server instance with a name contained in this list";
-          global = "startify_skiplist_server";
+          global = "skiplist_server";
           type = types.listOf types.str;
         };
 
         enableSpecial = mkDefaultOpt {
           description = "Show &lt;empty buffer&gt; and &lt;quit&gt;";
-          global = "startify_enable_special";
+          global = "enable_special";
           type = types.bool;
         };
 
         enableUnsafe = mkDefaultOpt {
           description = "Improves start time but reduces accuracy of the file list";
-          global = "startify_enable_unsafe";
+          global = "enable_unsafe";
           type = types.bool;
         };
 
         sessionRemoveLines = mkDefaultOpt {
           description = "Lines matching any of the patterns in this list will be removed from the session file";
-          global = "startify_session_remove_lines";
+          global = "session_remove_lines";
           type = types.listOf types.str;
         };
 
         sessionSaveVars = mkDefaultOpt {
           description = "List of variables for Startify to save into the session file";
-          global = "startify_session_savevars";
+          global = "session_savevars";
           type = types.listOf types.str;
         };
 
         sessionSaveCmds = mkDefaultOpt {
           description = "List of cmdline commands to run when loading the session";
-          global = "startify_session_savecmds";
+          global = "session_savecmds";
           type = types.listOf types.str;
         };
 
         sessionNumber = mkDefaultOpt {
           description = "Maximum number of sessions to display";
-          global = "startify_session_number";
+          global = "session_number";
           type = types.listOf types.str;
         };
 
         sessionSort = mkDefaultOpt {
           description = "Sort sessions by modification time rather than alphabetically";
-          global = "startify_session_sort";
+          global = "session_sort";
           type = types.bool;
         };
 
         customIndices = mkDefaultOpt {
           description = "Use this list as indices instead of increasing numbers";
-          global = "startify_custom_indices";
+          global = "custom_indices";
           type = types.listOf types.str;
         };
 
         customHeader = mkDefaultOpt {
           description = "Define your own header";
-          global = "startify_custom_header";
+          global = "custom_header";
           type = types.oneOf [types.str (types.listOf types.str)];
         };
 
         customQuotes = mkDefaultOpt {
           description = "Own quotes for the cowsay header";
-          global = "startify_custom_header_quotes";
+          global = "custom_header_quotes";
           # TODO this should also support funcrefs!
           type = types.listOf (types.listOf types.str);
         };
 
         customFooter = mkDefaultOpt {
           description = "Custom footer";
-          global = "startify_custom_footer";
+          global = "custom_footer";
           type = types.str;
         };
 
         disableAtVimEnter = mkDefaultOpt {
           description = "Don't run Startify at Vim startup";
-          global = "startify_disable_at_vimenter";
+          global = "disable_at_vimenter";
           type = types.bool;
         };
 
         relativePath = mkDefaultOpt {
           description = "If the file is in or below the current working directory, use a relative path";
-          global = "startify_relative_path";
+          global = "relative_path";
           type = types.bool;
         };
 
         useEnv = mkDefaultOpt {
           description = "Show environment variables in path, if their name is shorter than their value";
-          global = "startify_use_env";
+          global = "use_env";
           type = types.bool;
         };
       };


### PR DESCRIPTION
Avoid to repeat `plugin_name_` in front of every `global` when declaring a `mkPlugin` plugin.