### PR TITLE
plugins/notify: Fix typo for background_colour option

### DIFF
--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -16,6 +16,7 @@ with lib; let
 in {
   imports = [
     (optionWarnings.mkRenamedOption {
+      # 2023-03-24
       option = basePluginPath ++ ["backgroundColor"];
       newOption = basePluginPath ++ ["backgroundColour"];
     })

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -7,11 +7,20 @@
 with lib; let
   cfg = config.plugins.notify;
   helpers = import ../helpers.nix {inherit lib;};
+  optionWarnings = import ../../lib/option-warnings.nix {inherit lib;};
+  basePluginPath = ["plugins" "notify"];
   icon = mkOption {
     type = types.nullOr types.str;
     default = null;
   };
 in {
+  imports = [
+    (optionWarnings.mkRenamedOption {
+      option = basePluginPath ++ ["backgroundColor"];
+      newOption = basePluginPath ++ ["backgroundColour"];
+    })
+  ];
+
   options.plugins.notify = {
     enable = mkEnableOption "notify";
 
@@ -27,7 +36,7 @@ in {
       description = "Default timeout for notifications";
       default = null;
     };
-    backgroundColor = mkOption {
+    backgroundColour = mkOption {
       type = types.nullOr types.str;
       description = "For stages that change opacity this is treated as the highlight between the window";
       default = null;
@@ -56,7 +65,7 @@ in {
     setupOptions = with cfg; {
       stages = stages;
       timeout = timeout;
-      background_color = backgroundColor;
+      background_colour = backgroundColour;
       minimum_width = minimumWidth;
       icons = with icons; {
         ERROR = error;


### PR DESCRIPTION
`nvim-notify` uses `background_colour` rather than `background_color`

See: https://github.com/rcarriga/nvim-notify/blob/50d037041ada0895aeba4c0215cde6d11b7729c4/doc/nvim-notify.txt#L23

This PR additionally renames the configuration option to the correct camelCase name, and uses `optionWarnings.mkRenamedOption` to both warn about this change and map the old option to the new one.