### PR TITLE
tests/lib: Add basic unit tests for `helpers.toLuaObject`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,9 @@
               makeNixvim = self.legacyPackages."${system}".makeNixvim;
             })
             // {
+              lib-tests = import ./tests/lib-tests.nix {
+                inherit (pkgs) pkgs lib;
+              };
               pre-commit-check = pre-commit-hooks.lib.${system}.run {
                 src = ./.;
                 hooks = {

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -1,0 +1,85 @@
+# For shorter test iterations run the following in the root of the repo:
+#   `echo ':b checks.${builtins.currentSystem}.lib-tests' | nix repl .`
+{
+  pkgs,
+  lib,
+}: let
+  helpers = import ../lib/helpers.nix {inherit pkgs lib;};
+  results = pkgs.lib.runTests {
+    testToLuaObject = {
+      expr = helpers.toLuaObject {
+        foo = "bar";
+        qux = [1 2 3];
+      };
+      expected = ''{["foo"] = "bar",["qux"] = {1,2,3}}'';
+    };
+
+    testToLuaObjectNestedAttrs = {
+      expr = helpers.toLuaObject {
+        a = {
+          b = 1;
+          c = 2;
+          d = {e = 3;};
+        };
+      };
+      expected = ''{["a"] = {["b"] = 1,["c"] = 2,["d"] = {["e"] = 3}}}'';
+    };
+
+    testToLuaObjectNestedList = {
+      expr = helpers.toLuaObject [1 2 [3 4 [5 6]] 7];
+      expected = "{1,2,{3,4,{5,6}},7}";
+    };
+
+    testToLuaObjectNonStringPrims = {
+      expr = helpers.toLuaObject {
+        a = 1.0;
+        b = 2;
+        c = true;
+        d = false;
+        e = null;
+      };
+      expected = ''{["a"] = 1.000000,["b"] = 2,["c"] = true,["d"] = false}'';
+    };
+
+    testToLuaObjectNilPrim = {
+      expr = helpers.toLuaObject null;
+      expected = "nil";
+    };
+
+    testToLuaObjectStringPrim = {
+      expr = helpers.toLuaObject ''
+        foo\bar
+        baz'';
+      expected = ''"foo\\bar\nbaz"'';
+    };
+
+    testToLuaObjectShouldFilterNullAttrs = {
+      expr = helpers.toLuaObject {
+        a = null;
+        b = {};
+        c = [];
+        d = {
+          e = null;
+          f = {};
+        };
+      };
+      expected = ''{["b"] = {},["c"] = {},["d"] = {["f"] = {}}}'';
+    };
+  };
+in
+  if results == []
+  then pkgs.runCommand "lib-tests-success" {} "touch $out"
+  else
+    pkgs.runCommand "lib-tests-failure" {
+      results = pkgs.lib.concatStringsSep "\n" (
+        builtins.map (result: ''
+          ${result.name}:
+            expected: ${result.expected}
+            result: ${result.result}
+        '')
+        results
+      );
+    } ''
+      echo -e "Tests failed:\\n\\n$results" >&2
+      exit 1
+    ''

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -14,6 +14,21 @@
       expected = ''{["foo"] = "bar",["qux"] = {1,2,3}}'';
     };
 
+    testToLuaObjectRawLua = {
+      expr = helpers.toLuaObject {
+        __raw = "<lua code>";
+      };
+      expected = "<lua code>";
+    };
+
+    testToLuaObjectLuaTableMixingList = {
+      expr = helpers.toLuaObject {
+        "@...." = "foo";
+        bar = "baz";
+      };
+      expected = ''{"foo",["bar"] = "baz"}'';
+    };
+
     testToLuaObjectNestedAttrs = {
       expr = helpers.toLuaObject {
         a = {


### PR DESCRIPTION
This PR adds basic testing for Nix expressions using nixpkgs' `lib.runTests`,
as well as some unit tests for `helpers.toLuaObject`.

They'll run automatically with `nix flake check`, but can also be ran via `nix
repl` to reduce the number of checks to run:

```console
# nix repl .
Welcome to Nix 2.14.1. Type :? for help.

Loading installable 'git+file:///home/rummik/Source/pta2002/nixvim#'...
Added 10 variables.
nix-repl> :b checks.${builtins.currentSystem}.lib-tests

This derivation produced the following outputs:
  out -> /nix/store/9p6svspj4hbn1jd1xnb5vbd3y7qqc690-lib-tests-success

nix-repl>
```

It also pretty-prints the output from `lib.runTests`:

```console
nix-repl> :b checks.${builtins.currentSystem}.lib-tests
error: builder for '/nix/store/hn8m43v0ixanyzd8cf497wyx90vdjpsh-lib-tests-failure.drv' failed with exit code 1;
       last 6 log lines:
       > Tests failed:
       >
       > testToLuaObjectNestedList:
       >   expected: {1,2,{3,4,{5,6}}, 7}
       >   result: {1,2,{3,4,{5,6}},7}
       >
       For full logs, run 'nix log /nix/store/hn8m43v0ixanyzd8cf497wyx90vdjpsh-lib-tests-failure.drv'.

nix-repl>
```
