### PR TITLE
wrappers/standalone: handle assertions

### DIFF
--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -9,5 +9,14 @@ default_pkgs: modules: {
   eval = lib.evalModules {
     modules = (modules pkgs) ++ [module wrap];
   };
+
+  handleAssertions = config: let
+    failedAssertions = map (x: x.message) (lib.filter (x: !x.assertion) config.assertions);
+  in
+    if failedAssertions != []
+    then throw "\nFailed assertions:\n${builtins.concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+    else lib.showWarnings config.warnings config;
+
+  config = handleAssertions eval.config;
 in
-  eval.config.finalPackage
+  config.finalPackage


### PR DESCRIPTION
Assertions (which are used for deprecated and renamed options) where properly handled when using nixvim with home-manager and NixOS but not in standalone mode.
This is now fixed by applying the same logic as in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/62d5fcc12cca592022133807ff01e642c9e15a91/nixos/modules/system/activation/top-level.nix#L122-L126).