### PR TITLE
plugins/nvim-jdtls: add data and configuration options

### DIFF
--- a/tests/test-sources/plugins/languages/nvim-jdtls.nix
+++ b/tests/test-sources/plugins/languages/nvim-jdtls.nix
@@ -1,13 +1,15 @@
 {pkgs}: {
-  empty = {
-    plugins.nvim-jdtls.enable = true;
-  };
-
   example = {
     plugins.nvim-jdtls = {
       enable = true;
 
-      cmd = ["${pkgs.jdt-language-server}/bin/jdt-language-server"];
+      cmd = [
+        "${pkgs.jdt-language-server}/bin/jdt-language-server"
+        "-data"
+        "/dev/null"
+        "-configuration"
+        "/dev/null"
+      ];
 
       rootDir.__raw = "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})";
 
@@ -18,6 +20,15 @@
       initOptions = {
         bundles = {};
       };
+    };
+  };
+
+  dataAndConfiguration = {
+    plugins.nvim-jdtls = {
+      enable = true;
+
+      data = "/path/to/my/project";
+      configuration = "/path/to/configuration";
     };
   };
 }


### PR DESCRIPTION
Add the `data` and `configuration` options which act on the **default value** of the `cmd` option.
This is inspired from [what `nvim-lsp` does](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jdtls)