### PR TITLE
Add mapping description to generated lua for which-key.

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -55,9 +55,10 @@ with lib; rec {
           script = false;
           nowait = false;
           action = action;
+          description = null;
         }
         else {
-          inherit (action) silent expr unique noremap script nowait remap;
+          inherit (action) silent expr unique noremap script nowait remap description;
           action =
             if action.lua
             then mkRaw action.action
@@ -68,9 +69,11 @@ with lib; rec {
     builtins.attrValues (builtins.mapAttrs
       (key: action: {
         action = action.action;
-        config = lib.filterAttrs (_: v: v) {
-          inherit (action) silent expr unique noremap script nowait remap;
-        };
+        config =
+          lib.filterAttrs (_: v: v) {
+            inherit (action) silent expr unique noremap script nowait remap;
+          }
+          // {desc = action.description;};
         key = key;
         mode = mode;
       })


### PR DESCRIPTION
In `modules/keymaps.nix` we define a description:
```nix
description = helpers.mkNullOrOption types.str ''
  A textual description of this keybind, to be shown in which-key, if you have it.
'';
```
This is currently, as far as I am aware, ignored when generating lua `lib/helpers.nix`:
```nix
config = lib.filterAttrs (_: v: v) {
  inherit (action) silent expr unique noremap script nowait remap;
};
```

This pull request should fix that and add the description as `desc` in the keymap config. 

It might be worth considering to rename the nix option from `description` to `desc` to match the neovim config.