### PR TITLE
helpers/lib: toLuaObject ignore empty attrs

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -12,6 +12,8 @@ with lib; rec {
     then
       if hasAttr "__raw" args
       then args.__raw
+      else if hasAttr "__empty" args
+      then "{ }"
       else
         "{"
         + (concatStringsSep ","
@@ -20,7 +22,12 @@ with lib; rec {
               if head (stringToCharacters n) == "@"
               then toLuaObject v
               else "[${toLuaObject n}] = " + (toLuaObject v))
-            (filterAttrs (n: v: !isNull v) args)))
+            (filterAttrs
+              (
+                n: v:
+                  !isNull v && (toLuaObject v != "{}")
+              )
+              args)))
         + "}"
     else if builtins.isList args
     then "{" + concatMapStringsSep "," toLuaObject args + "}"
@@ -39,6 +46,8 @@ with lib; rec {
     else if isNull args
     then "nil"
     else "";
+
+  emptyTable = {"__empty" = null;};
 
   # Generates maps for a lua config
   genMaps = mode: maps: let

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -68,7 +68,7 @@
       expected = ''"foo\\bar\nbaz"'';
     };
 
-    testToLuaObjectShouldFilterNullAttrs = {
+    testToLuaObjectFilters = {
       expr = helpers.toLuaObject {
         a = null;
         b = {};
@@ -78,7 +78,21 @@
           f = {};
         };
       };
-      expected = ''{["b"] = {},["c"] = {},["d"] = {["f"] = {}}}'';
+      expected = ''{}'';
+    };
+
+    testToLuaObjectEmptyTable = {
+      expr = helpers.toLuaObject {
+        a = null;
+        b = {};
+        c = {__empty = null;};
+        d = {
+          e = null;
+          f = {};
+          g = helpers.emptyTable;
+        };
+      };
+      expected = ''{["c"] = { },["d"] = {["g"] = { }}}'';
     };
   };
 in


### PR DESCRIPTION
This PR makes `toLuaObject` ignore empty attrs like it was the case before #213.
The current version of `toLuaObject` (which translates empty attrs to an empty table in lua (`{}`) prevents us from using conventional nested options.
Although the _composite option_ (i.e. an option which has `submodule` as type, provided for example by `helpers.mkCompositeOption`) is working fine in most cases, it is preventing us from properly exposing renamed/removed/deprecated options.

This PR does not introduce any regression apart from eventual users which were setting options to empty attribute sets.

This PR also introduces an `{ __empty = ...; }` value to explicitly set an empty table. (Also available thanks to `helpers.emptyTable`.