### PR TITLE
plugins/bufferline: add TODO to remove warnings

### DIFF
--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -83,6 +83,8 @@ with lib; let
     pick_selected = "pickSelected";
   };
 in {
+  # Those renamed are from 2023-04-04.
+  # TODO: remove them in 1-2 months
   imports =
     [
       (


### PR DESCRIPTION
This is to not forget about removing deprecation warnings after a while.