### PR TITLE
nvim-cmp: do not pass in enabled = true

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -463,7 +463,13 @@ in {
 
   config = let
     options = {
-      enabled = cfg.enable;
+      # The upstream default value (which is a function) should not be overwritten.
+      # https://www.reddit.com/r/neovim/comments/vtw4vl/comment/if9zfdf/?utm_source=share&utm_medium=web2x&context=3
+      enabled =
+        if cfg.enable
+        then null
+        else false;
+
       performance = cfg.performance;
       preselect =
         helpers.ifNonNull' cfg.preselect


### PR DESCRIPTION
Since this means cmp is active in prompts, e.g. telescope

https://www.reddit.com/r/neovim/comments/vtw4vl/disable_nvimcmp_in_telescopes_buffer/