### PR TITLE
modules/lua-loader: add support for the new lua-loader

### DIFF
--- a/modules/lua-loader.nix
+++ b/modules/lua-loader.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.luaLoader;
+in {
+  options.luaLoader = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable/disable the experimental lua loader:
+
+        If `true`: Enables the experimental Lua module loader:
+          - overrides loadfile
+          - adds the lua loader using the byte-compilation cache
+          - adds the libs loader
+          - removes the default Neovim loade
+
+        If `false`: Disables the experimental Lua module loader:
+          - removes the loaders
+          - adds the default Neovim loader
+      '';
+    };
+  };
+
+  config = {
+    extraConfigLuaPre =
+      if cfg.enable
+      then "vim.loader.enable()"
+      else "vim.loader.disable()";
+  };
+}

--- a/tests/test-sources/modules/lua-loader.nix
+++ b/tests/test-sources/modules/lua-loader.nix
@@ -1,0 +1,9 @@
+{
+  enabled = {
+    luaLoader.enable = true;
+  };
+
+  disabled = {
+    luaLoader.enable = false;
+  };
+}


### PR DESCRIPTION
Add support for the experimental lua-loader introduced in neovim 0.9.
Documentation: https://neovim.io/doc/user/lua.html#lua-loader