### PR TITLE
plugins/conjure: init plugin

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -68,6 +68,7 @@
 
     ./utils/comment-nvim.nix
     ./utils/commentary.nix
+    ./utils/conjure.nix
     ./utils/easyescape.nix
     ./utils/endwise.nix
     ./utils/floaterm.nix

--- a/plugins/utils/conjure.nix
+++ b/plugins/utils/conjure.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.conjure;
+  helpers = import ../helpers.nix {inherit lib;};
+in {
+  options.plugins.conjure = {
+    enable = mkEnableOption "Conjure";
+
+    package = helpers.mkPackageOption "conjure" pkgs.vimPlugins.conjure;
+  };
+
+  config = mkIf cfg.enable {
+    extraPlugins = [cfg.package];
+  };
+}

--- a/tests/test-sources/plugins/utils/conjure.nix
+++ b/tests/test-sources/plugins/utils/conjure.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.conjure.enable = true;
+  };
+}


### PR DESCRIPTION
Creates an option for [Conjure](https://github.com/Olical/conjure). No options,
because there really isn't anything to configure.
