### PR TITLE
modules/output: Allow to specify text to add as extra files

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -86,6 +86,12 @@ in {
       description = "Extra lua packages to include with neovim";
       default = _: [];
     };
+
+    extraFiles = mkOption {
+      type = types.attrsOf types.str;
+      description = "Extra files to add to the runtime path";
+      default = {};
+    };
   };
 
   config = let

--- a/tests/test-sources/modules/extra-files.nix
+++ b/tests/test-sources/modules/extra-files.nix
@@ -1,0 +1,9 @@
+{
+  query = {
+    extraFiles = {
+      "queries/lua/injections.scm" = ''
+        ;; extends
+      '';
+    };
+  };
+}

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -26,12 +26,24 @@ in {
   configFiles = let
     cfg = config.programs.nixvim;
   in
-    lib.mapAttrs'
     (
-      _: file:
-        lib.nameValuePair
-        "nvim/${file.path}"
-        {text = file.content;}
+      lib.mapAttrs'
+      (
+        _: file:
+          lib.nameValuePair
+          "nvim/${file.path}"
+          {text = file.content;}
+      )
+      cfg.files
     )
-    cfg.files;
+    // (
+      lib.mapAttrs'
+      (
+        path: content:
+          lib.nameValuePair
+          "nvim/${path}"
+          {text = content;}
+      )
+      cfg.extraFiles
+    );
 }

--- a/wrappers/modules/files.nix
+++ b/wrappers/modules/files.nix
@@ -57,8 +57,9 @@ in {
     # A directory with all the files in it
     filesPlugin = pkgs.buildEnv {
       name = "nixvim-config";
-      paths = lib.mapAttrsToList (_: file: file.plugin) files;
-      ignoreCollisions = true; # Collisions can't happen by construction
+      paths =
+        (lib.mapAttrsToList (_: file: file.plugin) files)
+        ++ (lib.mapAttrsToList (path: content: pkgs.writeTextDir path content) config.extraFiles);
     };
   };
 }


### PR DESCRIPTION
To enable some features (like adding tree-sitter queries) we need to add files to specific directories in the runtime path (queries/lang/file.scm for tree-sitter queries for example).

This commit adds support for specifying such files. You must be careful to not have any collisions between `files` and `extraFiles`.