### PR TITLE
plugins/treesitter: Add injections to highlight lua in nixvim options

### DIFF
--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -91,6 +91,10 @@ in {
         default = {};
         description = "This is the configuration for extra modules. It should not be used directly";
       };
+
+      nixvimInjections =
+        mkEnableOption
+        "nixvim specific injections, like lua highlighting in extraConfigLua";
     };
   };
 
@@ -147,6 +151,20 @@ in {
         + ''
           require('nvim-treesitter.configs').setup(${helpers.toLuaObject tsOptions})
         '';
+
+      extraFiles = mkIf cfg.nixvimInjections {
+        "queries/nix/injections.scm" = ''
+          ;; extends
+
+          (binding
+            attrpath: (attrpath (identifier) @_path)
+            expression: [
+              (string_expression (string_fragment) @lua)
+              (indented_string_expression (string_fragment) @lua)
+            ]
+            (#match? @_path "^extraConfigLua(Pre|Post)?$"))
+        '';
+      };
 
       extraPlugins = with pkgs;
         if cfg.nixGrammars

--- a/tests/test-sources/plugins/languages/treesitter/treesitter.nix
+++ b/tests/test-sources/plugins/languages/treesitter/treesitter.nix
@@ -12,6 +12,13 @@
     };
   };
 
+  nixvimInjections = {
+    plugins.treesitter = {
+      enable = true;
+      nixvimInjections = true;
+    };
+  };
+
   # This needs a custom input
   # custom = {
   #   plugins.treesitter = {


### PR DESCRIPTION
This can look something like this: 
![image](https://user-images.githubusercontent.com/5623227/233679524-2d57af76-594c-4c95-ac62-eb7d3c4f1cd6.png)
