### PR TITLE
modules/clipboard: add new module to manage clipboard option and provider

### DIFF
--- a/modules/clipboard.nix
+++ b/modules/clipboard.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.clipboard;
+in {
+  options = {
+    clipboard = {
+      register = mkOption {
+        description = ''
+          Sets the register to use for the clipboard.
+          Learn more at https://neovim.io/doc/user/options.html#'clipboard'.
+        '';
+        type = with types;
+          nullOr
+          (either str (listOf str));
+        default = null;
+        example = "unnamedplus";
+      };
+
+      providers = mkOption {
+        type = types.submodule {
+          options =
+            mapAttrs
+            (
+              name: packageName: {
+                enable = mkEnableOption name;
+                package = mkPackageOption pkgs packageName {};
+              }
+            )
+            {
+              xclip = "xclip";
+              xsel = "xsel";
+            };
+        };
+        default = {};
+        description = ''
+          Package(s) to use as the clipboard provider.
+          Learn more at `:h clipboard`.
+        '';
+      };
+    };
+  };
+
+  config = {
+    options.clipboard = mkIf (!isNull cfg.register) cfg.register;
+
+    extraPackages =
+      mapAttrsToList
+      (n: v: v.package)
+      (filterAttrs (n: v: v.enable) cfg.providers);
+  };
+}

--- a/tests/test-sources/modules/clipboard.nix
+++ b/tests/test-sources/modules/clipboard.nix
@@ -1,0 +1,17 @@
+{pkgs}: {
+  example-with-str = {
+    clipboard = {
+      register = "unnamed";
+
+      providers.xclip.enable = true;
+    };
+  };
+
+  example-with-package = {
+    clipboard = {
+      register = ["unnamed" "unnamedplus"];
+
+      providers.xsel.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
Add a new module that lets the user easily manage the clipboard.
It allows to add a provider package.