### PR TITLE
flake: update inputs + fix nvim-tree option change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681465517,
-        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
+        "lastModified": 1682181988,
+        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
+        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681413034,
-        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
+        "lastModified": 1681831107,
+        "narHash": "sha256-pXl3DPhhul9NztSetUJw2fcN+RI3sGOYgKu29xpgnqw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
+        "rev": "b7ca8f6fff42f6af75c17f9438fed1686b7d855d",
         "type": "github"
       },
       "original": {

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -48,6 +48,20 @@ in {
     (optionWarnings.mkDeprecatedOption {
       option = basePluginPath ++ ["removeKeymaps"];
       alternative = basePluginPath ++ ["onAttach"];
+      message = ''
+        Mappings can now be customized from the `onAttach` function.
+        Learn more at `:help nvim-tree-mappings-legacy`.
+      '';
+    })
+    # Deprecate warning added 2023-04-24
+    # TODO Remove both this warning and the one above (removeKeymaps) in ~1 month (June).
+    (optionWarnings.mkDeprecatedOption {
+      option = basePluginPath ++ ["view" "mappings"];
+      alternative = basePluginPath ++ ["onAttach"];
+      message = ''
+        Mappings can now be customized from the `onAttach` function.
+        Learn more at `:help nvim-tree-mappings-legacy`.
+      '';
     })
   ];
 
@@ -373,7 +387,7 @@ in {
         Necessary when using a UI prompt decorator such as dressing.nvim or telescope-ui-select.nvim.
       '';
 
-      view = helpers.mkCompositeOption "Window / buffer setup." {
+      view = {
         centralizeSelection = helpers.defaultNullOpts.mkBool false ''
           When entering nvim-tree, reposition the view so that the current node is
           initially centralized, see |zz|.
@@ -1036,43 +1050,42 @@ in {
         on_attach = onAttach;
         remove_keymaps = removeKeymaps;
         select_prompts = selectPrompts;
-        view = with view;
-          ifNonNull' cfg.view {
-            centralize_selection = centralizeSelection;
-            inherit cursorline;
-            debounce_delay = debounceDelay;
-            hide_root_folder = hideRootFolder;
-            inherit width;
-            inherit side;
-            preserve_window_proportions = preserveWindowProportions;
-            inherit number;
-            inherit relativenumber;
-            inherit signcolumn;
-            mappings = with mappings;
-              ifNonNull' cfg.view.mappings {
-                custom_only = customOnly;
-                list =
-                  if list == null
-                  then null
-                  else
-                    map (
-                      mapping: {
-                        inherit (mapping) key action mode;
-                        action_cb =
-                          if (mapping.action_cb == null)
-                          then null
-                          else helpers.mkRaw mapping.action_cb;
-                      }
-                    )
-                    list;
-              };
-            float = with float;
-              ifNonNull' cfg.view.float {
-                inherit enable;
-                quit_on_focus_loss = quitOnFocusLoss;
-                open_win_config = openWinConfig;
-              };
-          };
+        view = with view; {
+          centralize_selection = centralizeSelection;
+          inherit cursorline;
+          debounce_delay = debounceDelay;
+          hide_root_folder = hideRootFolder;
+          inherit width;
+          inherit side;
+          preserve_window_proportions = preserveWindowProportions;
+          inherit number;
+          inherit relativenumber;
+          inherit signcolumn;
+          mappings = with mappings;
+            ifNonNull' cfg.view.mappings {
+              custom_only = customOnly;
+              list =
+                if list == null
+                then null
+                else
+                  map (
+                    mapping: {
+                      inherit (mapping) key action mode;
+                      action_cb =
+                        if (mapping.action_cb == null)
+                        then null
+                        else helpers.mkRaw mapping.action_cb;
+                    }
+                  )
+                  list;
+            };
+          float = with float;
+            ifNonNull' cfg.view.float {
+              inherit enable;
+              quit_on_focus_loss = quitOnFocusLoss;
+              open_win_config = openWinConfig;
+            };
+        };
         renderer = with renderer;
           ifNonNull' cfg.renderer {
             add_trailing = addTrailing;

--- a/tests/test-sources/plugins/filetrees/nvim-tree.nix
+++ b/tests/test-sources/plugins/filetrees/nvim-tree.nix
@@ -90,34 +90,6 @@
         number = false;
         relativenumber = false;
         signcolumn = "yes";
-        mappings = {
-          customOnly = false;
-          list = [
-            # remove a default mapping for cd
-            {
-              key = "<2-RightMouse>";
-              action = "";
-            }
-
-            # add multiple normal mode mappings for edit
-            {
-              key = ["<CR>" "o"];
-              action = "edit";
-              mode = "n";
-            }
-
-            # custom action
-            {
-              key = "p";
-              action = "print_the_node_path";
-              action_cb = ''
-                function(node)
-                  print(node.absolute_path)
-                end
-              '';
-            }
-          ];
-        };
         float = {
           enable = false;
           quitOnFocusLoss = true;


### PR DESCRIPTION
- Update flake inputs
- Deprecate `view.mappings` option in `nvim-tree` because it has been deprecated upstream