### PR TITLE
lualine: allow attrs in theme and fix disabledFiletypes

### DIFF
--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -99,7 +99,7 @@ in {
         default = true;
       };
 
-      theme = helpers.defaultNullOpts.mkStr "auto" "The theme to use for lualine-nvim.";
+      theme = helpers.defaultNullOpts.mkNullable (with types; either str attrs) "auto" "The theme to use for lualine-nvim.";
 
       componentSeparators = mkSeparatorsOption {
         leftDefault = "";
@@ -114,11 +114,11 @@ in {
       };
 
       disabledFiletypes = helpers.mkCompositeOption "Filetypes to disable lualine for." {
-        statusline = helpers.defaultNullOpts.mkNullable (types.str) "[]" ''
+        statusline = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
           Only ignores the ft for statusline.
         '';
 
-        winbar = helpers.defaultNullOpts.mkNullable (types.str) "[]" ''
+        winbar = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
           Only ignores the ft for winbar.
         '';
       };

--- a/tests/test-sources/plugins/statuslines/lualine.nix
+++ b/tests/test-sources/plugins/statuslines/lualine.nix
@@ -1,4 +1,4 @@
-{
+{pkgs}: {
   empty = {
     plugins.lualine.enable = true;
   };
@@ -40,9 +40,20 @@
   };
 
   example = {
+    extraPlugins = [pkgs.vimPlugins.gruvbox-nvim];
     plugins.lualine = {
       enable = true;
-      ignoreFocus = ["NvimTree"];
+      theme.__raw = ''
+        (function()
+          local custom_gruvbox = require("lualine.themes.gruvbox")
+          custom_gruvbox.normal.c.bg = '#112233'
+          return custom_gruvbox
+        end)()
+      '';
+      ignoreFocus = ["NvimTree" "neo-tree"];
+      disabledFiletypes = {
+        winbar = ["neo-tree"];
+      };
       sections = {
         lualine_c = [
           # you can specify only the sections you want to change


### PR DESCRIPTION
`theme` can be a lua table, for customization;
`disabledFiletypes` contain lists of filetypes.