### PR TITLE
plugins/nvim-lsp: add extraOptions for nvim-lsp language servers

### DIFF
--- a/tests/test-sources/plugins/nvim-lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/nvim-lsp/nvim-lsp.nix
@@ -33,6 +33,12 @@
         };
         nil_ls.enable = true;
         rust-analyzer.enable = true;
+        ruff-lsp = {
+          enable = true;
+          extraOptions = {
+            init_options.settings.args = ["--config=/path/to/config.toml"];
+          };
+        };
         pylsp = {
           enable = true;
           filetypes = ["python"];


### PR DESCRIPTION
Some `nvim-lsp` language servers need to be configured with options that are not explicitly wrapped by nixvim.
This commit adds an `extraOptions` to each language server.

Example:
```nix
plugins.nvim-lsp.servers = {
  ruff-lsp = {
    enable = true;
    extraOptions = {
      init_options.settings.args = [
        "--config=/path/to/config.toml"
      ];
    };
  };
};
```