### PR TITLE
plugins/nvim-lsp: add sourcekit language server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682526928,
-        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1682326782,
-        "narHash": "sha256-wj7p7iEwQXAfTZ6QokAe0dMbpQk5u7ympDnaiPvbv1w=",
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "56cd2d47a9c937be98ab225cf014b450f1533cdb",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
         "type": "github"
       },
       "original": {

--- a/plugins/nvim-lsp/language-servers/default.nix
+++ b/plugins/nvim-lsp/language-servers/default.nix
@@ -302,6 +302,11 @@ with lib; let
       settings = cfg: {rust-analyzer = cfg;};
     }
     {
+      name = "sourcekit";
+      description = "Enable the sourcekit language server, for Swift and C/C++/Objective-C";
+      package = pkgs.sourcekit-lsp;
+    }
+    {
       name = "tailwindcss";
       description = "Enable tailwindcss language server, for tailwindcss";
       package = pkgs.nodePackages."@tailwindcss/language-server";

--- a/tests/test-sources/plugins/nvim-lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/nvim-lsp/nvim-lsp.nix
@@ -73,6 +73,7 @@
         rnix-lsp.enable = true;
         ruff-lsp.enable = true;
         rust-analyzer.enable = true;
+        sourcekit.enable = true;
         tailwindcss.enable = true;
         terraformls.enable = true;
         texlab.enable = true;


### PR DESCRIPTION
Add the the [sourcekit language server](https://github.com/apple/sourcekit-lsp), for Swift and C/C++/Objective-C.
The package currently fails to build, so let's wait before merging.