### PR TITLE
plugins/nvim-lsp: fix extraSettings option warning

### DIFF
--- a/plugins/nvim-lsp/helpers.nix
+++ b/plugins/nvim-lsp/helpers.nix
@@ -79,7 +79,6 @@
             settings = settingsOptions;
 
             extraSettings = mkOption {
-              default = {};
               type = types.attrs;
               description = ''
                 Extra settings for the ${name} language server.
@@ -95,7 +94,10 @@
           // packageOption;
       };
 
-      config =
+      config = let
+        extraSettingsOption = options.plugins.lsp.servers.${name}.extraSettings;
+        extraSettingsAreDefined = extraSettingsOption.isDefined;
+      in
         mkIf cfg.enable
         {
           extraPackages =
@@ -118,17 +120,20 @@
                         end
                       ''
                     );
-                  settings = (settings cfg.settings) // cfg.extraSettings;
+                  settings =
+                    (settings cfg.settings)
+                    // (
+                      if extraSettingsAreDefined
+                      then cfg.extraSettings
+                      else {}
+                    );
                 }
                 // cfg.extraOptions;
             }
           ];
 
-          warnings = let
-            extraSettingsOption = options.plugins.lsp.servers.${name}.extraSettings;
-          in
-            optional
-            (extraSettingsOption.isDefined)
+          warnings =
+            optional extraSettingsAreDefined
             (
               let
                 optionPrefix = "plugins.lsp.servers.${name}";


### PR DESCRIPTION
The warning introduced in #351 was getting triggered even if the user was not defining the option in question.
This commit fixes that by removing the default value for that option.