### PR TITLE
envrc will now create .direnv folder

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,4 +4,5 @@ use_flake() {
   eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
 }
 
+mkdir -p "$(direnv_layout_dir)"
 use flake

--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,5 @@
-use_flake() {
-  watch_file flake.nix
-  watch_file flake.lock
-  eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
-}
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
 
-mkdir -p "$(direnv_layout_dir)"
 use flake


### PR DESCRIPTION
For direnv users, just using `direnv allow` will not always work

We could also consider removing the use flake function from `.envrc` since it should be built into direnv.