### PR TITLE
plugins/neo-tree: add documentSymbols options  and rename tabLabels option

### DIFF
--- a/tests/test-sources/plugins/filetrees/neo-tree.nix
+++ b/tests/test-sources/plugins/filetrees/neo-tree.nix
@@ -409,6 +409,23 @@
           };
         };
       };
+      documentSymbols = {
+        followCursor = false;
+        kinds = {
+          File = {
+            icon = "󰈙";
+            hl = "Tag";
+          };
+          Namespace = {
+            icon = "󰌗";
+            hl = "Include";
+          };
+        };
+        customKinds = {
+          "12" = "foo";
+          "15" = "bar";
+        };
+      };
     };
   };
 }

--- a/tests/test-sources/plugins/filetrees/neo-tree.nix
+++ b/tests/test-sources/plugins/filetrees/neo-tree.nix
@@ -41,12 +41,24 @@
         winbar = false;
         statusline = false;
         showScrolledOffParentNode = false;
-        tabLabels = {
-          filesystem = "  Files ";
-          buffers = "  Buffers ";
-          gitStatus = "  Git ";
-          diagnostics = " 裂Diagnostics ";
-        };
+        sources = [
+          {
+            source = "filesystem";
+            displayName = "  Files ";
+          }
+          {
+            source = "buffers";
+            displayName = "  Buffers ";
+          }
+          {
+            source = "gitStatus";
+            displayName = "  Git ";
+          }
+          {
+            source = "diagnostics";
+            displayName = " 裂Diagnostics ";
+          }
+        ];
         contentLayout = "start";
         tabsLayout = "equal";
         truncationCharacter = "…";


### PR DESCRIPTION
- rename the `tabLabels` option to reflect [upstream change](https://github.com/nvim-neo-tree/neo-tree.nvim/pull/877)
- add option `documentSymbols`