### PR TITLE
Added test for template and fixed check export for lib

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: nix flake check
+      - run: nix flake check ./templates/_wrapper/simple

--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,7 @@
           lib = import ./lib {
             inherit pkgs;
             inherit (pkgs) lib;
+            makeNixvim = self.legacyPackages."${system}".makeNixvim;
           };
         });
     in

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,6 @@
 # Args probably only needs pkgs and lib
 args: {
   # Add all exported modules here
-  check = import ./check.nix args;
+  check = import ../tests/test-derivation.nix args;
   helpers = import ./helpers.nix args;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,12 @@
 # Args probably only needs pkgs and lib
-args: {
+{
+  makeNixvim,
+  pkgs,
+  ...
+} @ args: {
   # Add all exported modules here
-  check = import ../tests/test-derivation.nix args;
+  check = import ../tests/test-derivation.nix {
+    inherit makeNixvim pkgs;
+  };
   helpers = import ./helpers.nix args;
 }

--- a/templates/_wrapper/README.md
+++ b/templates/_wrapper/README.md
@@ -1,0 +1,7 @@
+# templates/_wrapper
+
+This directory contains wrapper flakes for the nixvim templates.
+The purpose of the wrappers is to be able to run tests on templates deterministically on the branch or PR that is being worked on.
+It does this by overwriting the url of nixvim and other dependencies to a path within this repo.
+
+NOTE: It is important that we do not commit the `flake.lock` files here as that could cause problems with the check once any files are updated outside the wrapper. Also we cannot add `flake.lock` to `.gitignore` since nix will sometimes complain.

--- a/templates/_wrapper/README.md
+++ b/templates/_wrapper/README.md
@@ -4,4 +4,6 @@ This directory contains wrapper flakes for the nixvim templates.
 The purpose of the wrappers is to be able to run tests on templates deterministically on the branch or PR that is being worked on.
 It does this by overwriting the url of nixvim and other dependencies to a path within this repo.
 
+It is also used in the github workflows, so that we can always check if the template is working or not
+
 NOTE: It is important that we do not commit the `flake.lock` files here as that could cause problems with the check once any files are updated outside the wrapper. Also we cannot add `flake.lock` to `.gitignore` since nix will sometimes complain.

--- a/templates/_wrapper/simple/.gitignore
+++ b/templates/_wrapper/simple/.gitignore
@@ -1,3 +1,0 @@
-# We should ignore the lock file as every input here should be from paths
-# and the flake is simply a wrapper to get deterministic inputs
-flake.lock

--- a/templates/_wrapper/simple/.gitignore
+++ b/templates/_wrapper/simple/.gitignore
@@ -1,0 +1,3 @@
+# We should ignore the lock file as every input here should be from paths
+# and the flake is simply a wrapper to get deterministic inputs
+flake.lock

--- a/templates/_wrapper/simple/flake.nix
+++ b/templates/_wrapper/simple/flake.nix
@@ -1,0 +1,15 @@
+{
+  inputs = {
+    nixvim.url = "path:../../..";
+    # flake-utils = {
+    #   url = "github:numtide/flake-utils";
+    # };
+    simple = {
+      url = "path:../../simple";
+      inputs.nixvim.follows = "nixvim";
+      inputs.flake-utils.follows = "nixvim/flake-utils";
+    };
+  };
+
+  outputs = inputs: inputs.simple;
+}

--- a/templates/_wrapper/simple/flake.nix
+++ b/templates/_wrapper/simple/flake.nix
@@ -1,9 +1,6 @@
 {
   inputs = {
     nixvim.url = "path:../../..";
-    # flake-utils = {
-    #   url = "github:numtide/flake-utils";
-    # };
     simple = {
       url = "path:../../simple";
       inputs.nixvim.follows = "nixvim";

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -12,10 +12,10 @@
     flake-utils,
     ...
   } @ inputs: let
-    nixvimLib = nixvim.lib;
     config = import ./config; # import the module directly
   in
     flake-utils.lib.eachDefaultSystem (system: let
+      nixvimLib = nixvim.lib.${system};
       pkgs = import nixpkgs {inherit system;};
       nixvim' = nixvim.legacyPackages.${system};
       nvim = nixvim'.makeNixvimWithModule {
@@ -24,8 +24,8 @@
       };
     in {
       checks = {
-        # Run `nix check .` to verify that your config is not broken
-        default = nixvim.lib.${system}.check.checkNvim {
+        # Run `nix flake check .` to verify that your config is not broken
+        default = nixvimLib.check.mkTestDerivationFromNvim {
           inherit nvim;
           name = "A nixvim configuration";
         };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,7 +4,8 @@
   pkgs,
 }: let
   fetchTests = import ./fetch-tests.nix;
-  mkTestDerivation = import ./test-derivation.nix {inherit pkgs makeNixvim;};
+  test-derivation = import ./test-derivation.nix {inherit pkgs makeNixvim;};
+  mkTestDerivation = test-derivation.mkTestDerivation;
 
   # List of files containing configurations
   testFiles = fetchTests {

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -7,7 +7,7 @@
   mkTestDerivationFromNvim = {
     name,
     nvim,
-    dontRun,
+    dontRun ? false,
     ...
   }:
     pkgs.stdenv.mkDerivation {
@@ -55,5 +55,6 @@
       inherit name nvim;
       inherit (testAttributes) dontRun;
     };
-in
-  mkTestDerivation
+in {
+  inherit mkTestDerivation mkTestDerivationFromNvim;
+}


### PR DESCRIPTION
lib/default.nix was missing the check file, which is now moved to test-derivation.nix.
Here it was important to export both functions as the config for mkTestDerivation does not support imports from a configuration.

the check workflow also got a test for the template so we can keep it up to date, when making some breaking changes.