### PR TITLE
modules/commands: allow creation of user commands

### DIFF
--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  helpers = import ../lib/helpers.nix {inherit lib;};
+  commandAttributes = types.submodule {
+    options = {
+      command = mkOption {
+        type = types.str;
+        description = "The command to run";
+      };
+
+      nargs = mkOption {
+        type = types.nullOr (types.enum ["0" "1" "*" "?" "+"]);
+        default = null;
+        description = "The number of arguments to expect, see :h command-nargs";
+      };
+      complete = mkOption {
+        # TODO: This can take a lua function
+        type = types.nullOr types.str;
+        default = null;
+        description = "Tab-completion behaviour, see :h command-complete";
+      };
+      range = mkOption {
+        type = types.nullOr (types.oneOf [
+          types.bool
+          (types.enum ["%"])
+          types.int
+        ]);
+        default = null;
+        description = "Whether the command accepts a range, see :h command-range";
+      };
+      count = mkOption {
+        type = types.nullOr (types.oneOf [
+          types.bool
+          types.int
+        ]);
+        default = null;
+        description = "Whether the command accepts a count, see :h command-range";
+      };
+      addr = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Whether special characters relate to other things, see :h command-addr";
+      };
+      bang = helpers.defaultNullOpts.mkBool false "Whether this command can take a bang (!)";
+      bar = helpers.defaultNullOpts.mkBool false "Whether this command can be followed by a \"|\" and another command";
+      register = helpers.defaultNullOpts.mkBool false "The first argument to the command can be an optional register";
+      keepscript = helpers.defaultNullOpts.mkBool false "Do not use the location of where the user command was defined for verbose messages, use the location of where the command was invoked";
+      force = helpers.defaultNullOpts.mkBool false "Overwrite an existing user command";
+      desc = helpers.defaultNullOpts.mkStr "" "A description of the command";
+
+      # TODO: command-preview, need to grab a function here.
+    };
+  };
+in {
+  options.userCommands = mkOption {
+    type = types.attrsOf commandAttributes;
+    default = {};
+    description = "A list of user commands to add to the configuration";
+  };
+
+  config = let
+    cleanupCommand = _: cmd: {
+      command = cmd.command;
+      options = filterAttrs (name: _: name != "command") cmd;
+    };
+  in
+    mkIf (config.userCommands != []) {
+      extraConfigLua = helpers.wrapDo ''
+        local cmds = ${helpers.toLuaObject (mapAttrs cleanupCommand config.userCommands)};
+        for name,cmd in pairs(cmds) do
+          vim.api.nvim_create_user_command(name, cmd.command, cmd.options)
+        end
+      '';
+    };
+}

--- a/tests/test-sources/modules/commands.nix
+++ b/tests/test-sources/modules/commands.nix
@@ -1,0 +1,10 @@
+{
+  example = {
+    userCommands = {
+      "W" = {
+        command = ":W<CR>";
+        desc = "Write file";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Allow the creation of custom user commands, using the `userCommands` option.
