### PR TITLE
misc: remove deprecated/renamed options warnings

### DIFF
--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -7,7 +7,6 @@
 with lib; let
   cfg = config.plugins.barbar;
   helpers = import ../helpers.nix {inherit lib;};
-  basePluginPath = ["plugins" "barbar"];
 
   bufferOptions = {
     bufferIndex = helpers.mkNullOrOption types.bool ''
@@ -82,53 +81,6 @@ with lib; let
     orderByWindowNumber = "OrderByWindowNumber";
   };
 in {
-  # All the following renames/removes are from 2023-04-05.
-  # TODO: Remove them in 1-2 months.
-  imports = [
-    (mkRemovedOptionModule (basePluginPath ++ ["closable"]) "")
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["animations"])
-      (basePluginPath ++ ["animation"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["diagnostics"])
-      (basePluginPath ++ ["icons" "diagnostics"])
-    )
-    (mkRemovedOptionModule (basePluginPath ++ ["icons" "enable"]) "")
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "customColors"])
-      (basePluginPath ++ ["icons" "filetype" "customColors"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "separatorActive"])
-      (basePluginPath ++ ["icons" "separator" "left"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "separatorInactive"])
-      (basePluginPath ++ ["icons" "inactive" "separator" "left"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "separatorVisible"])
-      (basePluginPath ++ ["icons" "visible" "separator" "left"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "closeTab"])
-      (basePluginPath ++ ["icons" "button"])
-    )
-    (
-      mkRenamedOptionModule
-      (basePluginPath ++ ["icons" "closeTabModified"])
-      (basePluginPath ++ ["icons" "modified" "button"])
-    )
-  ];
-
   options.plugins.barbar =
     helpers.extraOptionsOptions
     // {

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -8,8 +8,6 @@ with lib; let
   cfg = config.plugins.bufferline;
   helpers = import ../helpers.nix args;
 
-  basePluginPath = ["plugins" "bufferline"];
-
   highlightOption = {
     fg = helpers.mkNullOrOption types.str "foreground color";
 
@@ -83,38 +81,6 @@ with lib; let
     pick_selected = "pickSelected";
   };
 in {
-  # Those renamed are from 2023-04-04.
-  # TODO: remove them in 1-2 months
-  imports =
-    [
-      (
-        mkRenamedOptionModule
-        (basePluginPath ++ ["indicatorIcon"])
-        (basePluginPath ++ ["indicator" "icon"])
-      )
-    ]
-    ++ (
-      lists.flatten (
-        map (
-          highlightOptionName: let
-            prefix = basePluginPath ++ ["highlights" highlightOptionName];
-          in [
-            (
-              mkRenamedOptionModule
-              (prefix ++ ["guifg"])
-              (prefix ++ ["fg"])
-            )
-            (
-              mkRenamedOptionModule
-              (prefix ++ ["guibg"])
-              (prefix ++ ["bg"])
-            )
-          ]
-        )
-        (attrValues highlightOptions)
-      )
-    );
-
   options = {
     plugins.bufferline =
       helpers.extraOptionsOptions

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -1,15 +1,11 @@
 {
   pkgs,
-  config,
   lib,
   ...
 } @ args:
 with lib; let
   lspHelpers = import ../helpers.nix args;
   helpers = import ../../helpers.nix {inherit lib;};
-
-  optionWarnings = import ../../../lib/option-warnings.nix args;
-  basePluginPath = ["plugins" "lsp" "servers"];
 
   servers = [
     {
@@ -355,11 +351,5 @@ with lib; let
 in {
   imports =
     lib.lists.map (lspHelpers.mkLsp) servers
-    ++ [./pylsp.nix]
-    ++ [
-      (optionWarnings.mkRenamedOption {
-        option = basePluginPath ++ ["sumneko-lua"];
-        newOption = basePluginPath ++ ["lua-ls"];
-      })
-    ];
+    ++ [./pylsp.nix];
 }

--- a/plugins/utils/floaterm.nix
+++ b/plugins/utils/floaterm.nix
@@ -3,12 +3,10 @@
   config,
   lib,
   ...
-} @ args:
+}:
 with lib; let
   cfg = config.plugins.floaterm;
   helpers = import ../helpers.nix {inherit lib;};
-  optionWarnings = import ../../lib/option-warnings.nix args;
-  basePluginPath = ["plugins" "floaterm"];
 
   settings = {
     shell = {
@@ -150,25 +148,6 @@ with lib; let
     };
   };
 in {
-  imports = [
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["winType"];
-      newOption = basePluginPath ++ ["wintype"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["winWidth"];
-      newOption = basePluginPath ++ ["width"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["winHeight"];
-      newOption = basePluginPath ++ ["height"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["borderChars"];
-      newOption = basePluginPath ++ ["borderchars"];
-    })
-  ];
-
   options.plugins.floaterm = let
     # Misc options
     # `OPTION = VALUE`

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -4,54 +4,8 @@
   ...
 } @ args:
 with lib;
-with import ../helpers.nix {inherit lib;}; let
-  optionWarnings = import ../../lib/option-warnings.nix args;
-  basePluginPath = ["plugins" "magma-nvim"];
-in
-  {
-    # Those renames happended on 03-24-2023 (TODO remove in 1-2 months)
-    imports =
-      map (
-        {
-          oldName,
-          newName,
-        }:
-          optionWarnings.mkRenamedOption {
-            option = basePluginPath ++ [oldName];
-            newOption = basePluginPath ++ [newName];
-          }
-      ) [
-        {
-          oldName = "image_provider";
-          newName = "imageProvider";
-        }
-        {
-          oldName = "automatically_open_output";
-          newName = "automaticallyOpenOutput";
-        }
-        {
-          oldName = "wrap_output";
-          newName = "wrapOutput";
-        }
-        {
-          oldName = "output_window_borders";
-          newName = "outputWindowBorders";
-        }
-        {
-          oldName = "cell_highlight_group";
-          newName = "cellHighlightGroup";
-        }
-        {
-          oldName = "save_path";
-          newName = "savePath";
-        }
-        {
-          oldName = "show_mimetype_debug";
-          newName = "showMimetypeDebug";
-        }
-      ];
-  }
-  // mkPlugin args {
+with import ../helpers.nix {inherit lib;};
+  mkPlugin args {
     name = "magma-nvim";
     description = "magma-nvim";
     package = pkgs.vimPlugins.magma-nvim-goose;

--- a/plugins/utils/mark-radar.nix
+++ b/plugins/utils/mark-radar.nix
@@ -3,33 +3,11 @@
   config,
   lib,
   ...
-} @ args:
+}:
 with lib; let
   cfg = config.plugins.mark-radar;
   helpers = import ../helpers.nix {inherit lib;};
-  optionWarnings = import ../../lib/option-warnings.nix args;
-  basePluginPath = ["plugins" "mark-radar"];
 in {
-  # Those renames were done on 03-24-2023
-  imports = [
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["highlight_background"];
-      newOption = basePluginPath ++ ["backgroundHighlight"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["background_highlight_group"];
-      newOption = basePluginPath ++ ["backgroundHighlightGroup"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["highlight_group"];
-      newOption = basePluginPath ++ ["highlightGroup"];
-    })
-    (optionWarnings.mkRenamedOption {
-      option = basePluginPath ++ ["set_default_keybinds"];
-      newOption = basePluginPath ++ ["setDefaultMappings"];
-    })
-  ];
-
   options.plugins.mark-radar =
     helpers.extraOptionsOptions
     // {

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -7,21 +7,11 @@
 with lib; let
   cfg = config.plugins.notify;
   helpers = import ../helpers.nix {inherit lib;};
-  optionWarnings = import ../../lib/option-warnings.nix {inherit lib;};
-  basePluginPath = ["plugins" "notify"];
   icon = mkOption {
     type = types.nullOr types.str;
     default = null;
   };
 in {
-  imports = [
-    (optionWarnings.mkRenamedOption {
-      # 2023-03-24
-      option = basePluginPath ++ ["backgroundColor"];
-      newOption = basePluginPath ++ ["backgroundColour"];
-    })
-  ];
-
   options.plugins.notify = {
     enable = mkEnableOption "notify";
 


### PR DESCRIPTION
Those warnings in various plugins are 1 month old or older.
I now suggest that we remove them.