### PR TITLE
feat: register mapping with no actions in which-key when enabled

### DIFF
--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -86,5 +86,7 @@
         filetypes = [];
       };
     };
+    # Simple mapping with only Description
+    maps.normal."ff".desc = "Test";
   };
 }


### PR DESCRIPTION
With these changes I can create bindings without a action attribute when which-key is enabled.
This is helpful for nested bindings.
Example: 
\<leader>ff = something
\<leader>fw = something_else

In which key when you press \<leader> it'll show "\<leader>f" as `+prefix`. We can now do
```nix
"<leader>f" = {
  desc = " Files";
};
```
so it shows the desc in which-key instead of just `+prefix`