### PR TITLE
nvim-lsp: fix package option (null) + test

### DIFF
--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -101,7 +101,11 @@
         mkIf cfg.enable
         {
           extraPackages =
-            (optional (package != null) cfg.package)
+            (
+              optional
+              ((package != null) && (cfg.package != null))
+              cfg.package
+            )
             ++ (mapAttrsToList (name: _: cfg."${name}Package") extraPackages);
 
           plugins.lsp.enabledServers = [

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -31,6 +31,11 @@
             print('The clangd language server has been attached !')
           '';
         };
+        # Do not install the language server using nixvim
+        gopls = {
+          enable = true;
+          package = null;
+        };
         nil_ls.enable = true;
         rust-analyzer.enable = true;
         ruff-lsp = {


### PR DESCRIPTION
Fixes the `package` option for the language servers:
```
error: A definition for option `extraPackages."[definition 1-entry 1]"' is not of type `package'. Definition values:
       - In `/nix/store/llszkbhrsv3sscnhw8mn00m3id363wd8-source/plugins/lsp/language-servers': null
```

Also add a test to avoid any regression.