### PR TITLE
nvim-lsp: add installLanguageServer option for servers

### DIFF
--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -32,7 +32,7 @@
         then {
           package = mkOption {
             default = package;
-            type = types.nullOr types.package;
+            type = types.package;
           };
         }
         else {};
@@ -42,9 +42,18 @@
           {
             enable = mkEnableOption description;
 
+            installLanguageServer = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Whether nixvim should take care of installing the language server.";
+            };
+
             cmd = mkOption {
               type = with types; nullOr (listOf str);
-              default = cmd cfg;
+              default =
+                if cfg.installLanguageServer
+                then cmd cfg
+                else null;
             };
 
             filetypes = helpers.mkNullOrOption (types.listOf types.str) ''
@@ -103,7 +112,7 @@
           extraPackages =
             (
               optional
-              ((package != null) && (cfg.package != null))
+              (cfg.installLanguageServer && (package != null))
               cfg.package
             )
             ++ (mapAttrsToList (name: _: cfg."${name}Package") extraPackages);

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -34,7 +34,7 @@
         # Do not install the language server using nixvim
         gopls = {
           enable = true;
-          package = null;
+          installLanguageServer = false;
         };
         nil_ls.enable = true;
         rust-analyzer.enable = true;


### PR DESCRIPTION
By default, for each enabled `plugins.lsp.servers`, `nixvim` installs the corresponding language server thanks to `nixpkgs`.
For some reason, a user might want to disable this behavior and limit the role of `nixvim` to wrap the `nvim-lspconfig` options without interfering more.

Hence, this PR adds a `installLanguageServer` option (defaulting to `true`) that, if disabled sets the `cmd` option default value to `null` and ignores the `package` option value.

Please note that the `package` option does not accept `null` anymore.