### PR TITLE
plugins/alpha-nvim: add alpha-nvim plugin module + tests

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -68,6 +68,7 @@
 
     ./ui/noice.nix
 
+    ./utils/alpha.nix
     ./utils/comment-nvim.nix
     ./utils/commentary.nix
     ./utils/conjure.nix

--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -1,0 +1,232 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.alpha;
+
+  helpers = import ../helpers.nix {inherit lib;};
+
+  sectionType = types.enum ["group" "padding" "text"];
+  themeType = types.enum ["dashboard" "startify" "theta"];
+
+  mkAlphaSectionOption = type:
+    types.submodule {
+      options = {
+        type = mkOption {
+          type = type;
+          description = "Type of section";
+        };
+
+        val = mkOption {
+          type = with types;
+            oneOf [
+              (either str int)
+              (listOf (
+                either
+                str
+                (submodule {
+                  options = {
+                    shortcut = helpers.mkNullOrOption str "Shortcut for keymap";
+                    desc = helpers.mkNullOrOption str "Description to display for keymap";
+                    command = helpers.mkNullOrOption str "Command to run for keymap";
+                  };
+                })
+              ))
+            ];
+          default = null;
+          description = "Value for section";
+        };
+
+        opts = mkOption {
+          type = types.submodule {
+            options = {
+              spacing = mkOption {
+                type = types.int;
+                default = 0;
+                description = "Spacing between grouped components";
+              };
+
+              hl = mkOption {
+                type = types.str;
+                default = "Keyword";
+                description = "HighlightGroup to apply";
+              };
+
+              position = mkOption {
+                type = types.str;
+                default = "center";
+                description = "How to align section";
+              };
+
+              margin = mkOption {
+                type = types.int;
+                default = 0;
+                description = "Margin for section";
+              };
+            };
+          };
+          default = {};
+          description = "Additional options for the section";
+        };
+      };
+    };
+in {
+  options = {
+    plugins.alpha = {
+      enable = mkEnableOption "alpha";
+
+      package = helpers.mkPackageOption "alpha" pkgs.vimPlugins.alpha-nvim;
+
+      theme = mkOption {
+        description = "Optional theme for alpha-nvim, one of: dashboard, startify, theta";
+        type = themeType;
+        default = "dashboard";
+      };
+
+      iconsEnabled = mkOption {
+        type = types.bool;
+        description = "Toggle icon support. Installs nvim-web-devicons.";
+        default = true;
+      };
+
+      layout = with helpers;
+        mkOption {
+          default = [
+            {
+              type = "padding";
+              val = 2;
+            }
+            {
+              type = "text";
+              val = [
+                "  ███╗   ██╗██╗██╗  ██╗██╗   ██╗██╗███╗   ███╗  "
+                "  ████╗  ██║██║╚██╗██╔╝██║   ██║██║████╗ ████║  "
+                "  ██╔██╗ ██║██║ ╚███╔╝ ██║   ██║██║██╔████╔██║  "
+                "  ██║╚██╗██║██║ ██╔██╗ ╚██╗ ██╔╝██║██║╚██╔╝██║  "
+                "  ██║ ╚████║██║██╔╝ ██╗ ╚████╔╝ ██║██║ ╚═╝ ██║  "
+                "  ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝  ╚═══╝  ╚═╝╚═╝     ╚═╝  "
+              ];
+              opts = {
+                position = "center";
+                hl = "Type";
+              };
+            }
+            {
+              type = "padding";
+              val = 2;
+            }
+            {
+              type = "group";
+              val = [
+                {
+                  shortcut = "SPC sf";
+                  desc = "  Find file";
+                  command = ":Telescope find_files <CR>";
+                }
+                {
+                  shortcut = "SPC sr";
+                  desc = "  Recently used files";
+                  command = ":Telescope oldfiles <CR>";
+                }
+                {
+                  shortcut = "SPC sg";
+                  desc = "  Find text";
+                  command = ":Telescope live_grep <CR>";
+                }
+                {
+                  shortcut = "SPC q";
+                  desc = "  Quit Neovim";
+                  command = ":qa<CR>";
+                }
+              ];
+            }
+            {
+              type = "padding";
+              val = 2;
+            }
+            {
+              type = "text";
+              val = "Don't Stop Until You're Proud";
+              opts = {
+                position = "center";
+                hl = "Keyword";
+              };
+            }
+          ];
+          description = "List of sections to layout for the dashboard";
+          type = types.listOf (mkAlphaSectionOption sectionType);
+        };
+    };
+  };
+
+  config = with helpers; let
+    processButton = button: let
+      stringifyButton = button: ''button("${button.shortcut}", "${button.desc}", "${button.command}")'';
+    in
+      mkRaw (stringifyButton button);
+
+    processButtons = attrset:
+      if attrset.type == "group"
+      then attrset // {val = builtins.map processButton attrset.val;}
+      else attrset;
+
+    options = {
+      theme = cfg.theme;
+      iconsEnabled = cfg.iconsEnabled;
+      layout = builtins.map processButtons cfg.layout;
+    };
+  in
+    mkIf cfg.enable {
+      extraPlugins =
+        [
+          cfg.package
+        ]
+        ++ (optional cfg.iconsEnabled pkgs.vimPlugins.nvim-web-devicons);
+      extraConfigLua = ''
+        local leader = "SPC"
+        --- @param sc string
+        --- @param txt string
+        --- @param keybind string? optional
+        --- @param keybind_opts table? optional
+        local function button(sc, txt, keybind, keybind_opts)
+            local sc_ = sc:gsub("%s", ""):gsub(leader, "<leader>")
+
+            local opts = {
+                position = "center",
+                shortcut = sc,
+                cursor = 3,
+                width = 50,
+                align_shortcut = "right",
+                hl_shortcut = "Keyword",
+            }
+            if keybind then
+                keybind_opts = vim.F.if_nil(keybind_opts, { noremap = true, silent = true, nowait = true })
+                opts.keymap = { "n", sc_, keybind, keybind_opts }
+            end
+
+            local function on_press()
+                local key = vim.api.nvim_replace_termcodes(keybind or sc_ .. "<Ignore>", true, false, true)
+                vim.api.nvim_feedkeys(key, "t", false)
+            end
+
+            return {
+                type = "button",
+                val = txt,
+                on_press = on_press,
+                opts = opts,
+            }
+        end
+
+        local config = {
+          layout = ${toLuaObject options.layout},
+          opts = {
+            margin = 5,
+          },
+        }
+        require('alpha').setup(config)
+      '';
+    };
+}

--- a/tests/test-sources/plugins/utils/alpha.nix
+++ b/tests/test-sources/plugins/utils/alpha.nix
@@ -1,0 +1,5 @@
+{pkgs}: {
+  empty = {
+    plugins.alpha.enable = true;
+  };
+}


### PR DESCRIPTION
Added the alpha greeter for Neovim https://github.com/goolord/alpha-nvim).

Feel free to comment on the design choice(s). There's basically two options:
1. override the default themes: startify, dashboard, theta (I'm not sure how to implement this)
2. Allow access to the lower level API through the opts (I think this fits best the Nixvim philosophy)

A few things I'm not sure how to implement but would be nice to have:
- allowing the user to provide a `button` function to be used in the sections.
- Providing guardrails so a user can't mix configuration options i.e. only padding sections can have val is int etc.