### PR TITLE
barbar.nvim: fix 'requires' (fixes #380)

### DIFF
--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -129,7 +129,8 @@ in {
       icons =
         stateOptions
         // (
-          mapAttrs (name: description:
+          mapAttrs
+          (name: description:
             mkOption {
               type = types.submodule {
                 options = stateOptions;
@@ -349,7 +350,7 @@ in {
       maps.normal = mkMerge userKeymapsList;
 
       extraConfigLua = ''
-        require('bufferline').setup(${helpers.toLuaObject setupOptions})
+        require('barbar').setup(${helpers.toLuaObject setupOptions})
       '';
     };
 }


### PR DESCRIPTION
The config was requiring 'bufferline' instead of 'barbar', as pointed out in #380. This fixes that.
