### PR TITLE
plugins/nvim-lsp: add rootDir option for language servers

### DIFF
--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -67,6 +67,12 @@
               `:LspStart` (|lspconfig-commands|).
             '';
 
+            rootDir = helpers.mkNullOrOption types.str ''
+              A function (or function handle) which returns the root of the project used to
+              determine if lspconfig should launch a new language server, or attach a previously
+              launched server when you open a new buffer matching the filetype of the server.
+            '';
+
             onAttach =
               helpers.mkCompositeOption "Server specific on_attach behavior."
               {
@@ -123,6 +129,9 @@
               extraOptions =
                 {
                   inherit (cfg) cmd filetypes autostart;
+                  root_dir =
+                    helpers.ifNonNull' cfg.rootDir
+                    (helpers.mkRaw cfg.rootDir);
                   on_attach =
                     helpers.ifNonNull' cfg.onAttach
                     (

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -49,6 +49,13 @@
           filetypes = ["python"];
           autostart = false;
         };
+        # rootDir
+        typst-lsp = {
+          enable = true;
+          rootDir = ''
+            require 'lspconfig.util'.root_pattern('.git', 'main.typ')
+          '';
+        };
       };
     };
   };


### PR DESCRIPTION
Maps the `nvim-lspconfig` common `root_dir` option for each language server.