### PR TITLE
plugins/nvim-cmp: update options

### DIFF
--- a/tests/test-sources/plugins/completion/nvim-cmp.nix
+++ b/tests/test-sources/plugins/completion/nvim-cmp.nix
@@ -20,6 +20,8 @@
         debounce = 60;
         throttle = 30;
         fetchingTimeout = 500;
+        asyncBudget = 1;
+        maxViewEntries = 200;
       };
 
       preselect = "Item";


### PR DESCRIPTION
- The `source[n].max_item_count` option has been removed upstream. Hence, remove the corresponding `maxItemCount` option
- Add missing `performance` options: `asyncBudget` and `maxViewEntries`