### PR TITLE
plugins/completion/copilot: use nodejs-18_x

### DIFF
--- a/plugins/completion/copilot.nix
+++ b/plugins/completion/copilot.nix
@@ -34,7 +34,7 @@ in {
     extraPlugins = [cfg.package];
     globals =
       {
-        copilot_node_command = "${pkgs.nodejs-16_x}/bin/node";
+        copilot_node_command = "${pkgs.nodejs-18_x}/bin/node";
         copilot_filetypes = cfg.filetypes;
       }
       // (


### PR DESCRIPTION
Fixes #394

nodejs-16 is EOL and has been marked as insecure in nixpkgs. This change makes copilot use nodejs-18 which is the current LTS

I've used and tested this change all week-end and found no issues
