### PR TITLE
plugins/nvim-lsp: add julials language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -178,6 +178,13 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/vscode-json-language-server" "--stdio"];
     }
     {
+      name = "julials";
+      description = "Enable julials, for Julia";
+      # The julia language server has to be installed from julia and thus is not packaged "as is" in
+      # nixpkgs.
+      package = null;
+    }
+    {
       name = "lua-ls";
       description = "Enable lua LS, for lua";
       # Use the old name of the lua LS if the user is on a stable branch of nixpkgs

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -79,6 +79,7 @@
         hls.enable = true;
         html.enable = true;
         jsonls.enable = true;
+        julials.enable = true;
         lua-ls.enable = true;
         metals.enable = true;
         nil_ls.enable = true;


### PR DESCRIPTION
Add the [`julials`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#julials) language server configuration in `nvim-lsp`.