### PR TITLE
plugins/ts-autotag: init + test

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -43,6 +43,7 @@
     ./languages/treesitter/treesitter-playground.nix
     ./languages/treesitter/treesitter-rainbow.nix
     ./languages/treesitter/treesitter-refactor.nix
+    ./languages/treesitter/ts-autotag.nix
     ./languages/typst/typst-vim.nix
     ./languages/vimtex.nix
     ./languages/zig.nix

--- a/plugins/languages/treesitter/treesitter-context.nix
+++ b/plugins/languages/treesitter/treesitter-context.nix
@@ -49,6 +49,10 @@ in {
     cfg = config.plugins.treesitter-context;
   in
     mkIf cfg.enable {
+      warnings = mkIf (!config.plugins.treesitter.enable) [
+        "Nixvim: treesitter-context needs treesitter to function as intended"
+      ];
+
       extraPlugins = [cfg.package];
 
       plugins.treesitter.moduleConfig.context = {

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -174,7 +174,7 @@ in {
         '';
       };
 
-      extraPlugins = with pkgs;
+      extraPlugins =
         if cfg.nixGrammars
         then [(cfg.package.withPlugins (_: cfg.grammarPackages))]
         else [cfg.package];

--- a/plugins/languages/treesitter/ts-autotag.nix
+++ b/plugins/languages/treesitter/ts-autotag.nix
@@ -1,0 +1,89 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+with lib; let
+  helpers = import ../../helpers.nix {inherit lib;};
+in {
+  options.plugins.ts-autotag =
+    helpers.extraOptionsOptions
+    // {
+      enable = mkEnableOption "nvim-ts-autotag";
+
+      package = helpers.mkPackageOption "ts-autotag" pkgs.vimPlugins.nvim-ts-autotag;
+
+      filetypes =
+        helpers.defaultNullOpts.mkNullable
+        (with types; listOf str)
+        ''
+          [
+            "html"
+            "javascript"
+            "typescript"
+            "javascriptreact"
+            "typescriptreact"
+            "svelte"
+            "vue"
+            "tsx"
+            "jsx"
+            "rescript"
+            "xml"
+            "php"
+            "markdown"
+            "astro"
+            "glimmer"
+            "handlebars"
+            "hbs"
+          ]
+        ''
+        "Filetypes for which ts-autotag should be enabled.";
+
+      skipTags =
+        helpers.defaultNullOpts.mkNullable
+        (with types; listOf str)
+        ''
+          [
+            "area"
+            "base"
+            "br"
+            "col"
+            "command"
+            "embed"
+            "hr"
+            "img"
+            "slot"
+            "input"
+            "keygen"
+            "link"
+            "meta"
+            "param"
+            "source"
+            "track"
+            "wbr"
+            "menuitem"
+          ]
+        ''
+        "Which tags to skip.";
+    };
+
+  config = let
+    cfg = config.plugins.ts-autotag;
+  in
+    mkIf cfg.enable {
+      warnings = mkIf (!config.plugins.treesitter.enable) [
+        "Nixvim: ts-autotag needs treesitter to function as intended"
+      ];
+
+      extraPlugins = [cfg.package];
+
+      plugins.treesitter.moduleConfig.autotag =
+        {
+          enable = true;
+          inherit (cfg) filetypes;
+          skip_tags = cfg.skipTags;
+        }
+        // cfg.extraOptions;
+    };
+}

--- a/tests/test-sources/plugins/languages/treesitter/ts-autotag.nix
+++ b/tests/test-sources/plugins/languages/treesitter/ts-autotag.nix
@@ -1,0 +1,56 @@
+{
+  empty = {
+    plugins = {
+      treesitter.enable = true;
+      ts-autotag.enable = true;
+    };
+  };
+
+  default = {
+    plugins = {
+      treesitter.enable = true;
+      ts-autotag = {
+        enable = true;
+        filetypes = [
+          "html"
+          "javascript"
+          "typescript"
+          "javascriptreact"
+          "typescriptreact"
+          "svelte"
+          "vue"
+          "tsx"
+          "jsx"
+          "rescript"
+          "xml"
+          "php"
+          "markdown"
+          "astro"
+          "glimmer"
+          "handlebars"
+          "hbs"
+        ];
+        skipTags = [
+          "area"
+          "base"
+          "br"
+          "col"
+          "command"
+          "embed"
+          "hr"
+          "img"
+          "slot"
+          "input"
+          "keygen"
+          "link"
+          "meta"
+          "param"
+          "source"
+          "track"
+          "wbr"
+          "menuitem"
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for the  [nvim-ts-autotag](https://github.com/windwp/nvim-ts-autotag) plugin.

Fixes #402.