### PR TITLE
plugins/ts-context-commentstring: init + test

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -44,6 +44,7 @@
     ./languages/treesitter/treesitter-rainbow.nix
     ./languages/treesitter/treesitter-refactor.nix
     ./languages/treesitter/ts-autotag.nix
+    ./languages/treesitter/ts-context-commentstring.nix
     ./languages/typst/typst-vim.nix
     ./languages/vimtex.nix
     ./languages/zig.nix

--- a/plugins/languages/treesitter/ts-context-commentstring.nix
+++ b/plugins/languages/treesitter/ts-context-commentstring.nix
@@ -1,0 +1,37 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+with lib; let
+  helpers = import ../../helpers.nix {inherit lib;};
+in {
+  options.plugins.ts-context-commentstring =
+    helpers.extraOptionsOptions
+    // {
+      enable = mkEnableOption "nvim-ts-context-commentstring";
+
+      package =
+        helpers.mkPackageOption
+        "ts-context-commentstring"
+        pkgs.vimPlugins.nvim-ts-context-commentstring;
+    };
+
+  config = let
+    cfg = config.plugins.ts-context-commentstring;
+  in
+    mkIf cfg.enable {
+      warnings = mkIf (!config.plugins.treesitter.enable) [
+        "Nixvim: ts-context-commentstring needs treesitter to function as intended"
+      ];
+
+      extraPlugins = [cfg.package];
+
+      plugins.treesitter.moduleConfig.context_commentstring =
+        {
+          enable = true;
+        }
+        // cfg.extraOptions;
+    };
+}

--- a/tests/test-sources/plugins/languages/treesitter/ts-context-commentstring.nix
+++ b/tests/test-sources/plugins/languages/treesitter/ts-context-commentstring.nix
@@ -1,0 +1,10 @@
+{
+  empty = {
+    plugins = {
+      treesitter.enable = true;
+      ts-context-commentstring.enable = true;
+    };
+  };
+
+  # This plugin has no option
+}


### PR DESCRIPTION
Add support for the [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) plugin.

Fixes #401.