### PR TITLE
plugins/bufferline: add new tab styles

### DIFF
--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -148,7 +148,7 @@ in {
         rightTruncMarker = helpers.defaultNullOpts.mkStr "" "right trunc marker";
 
         separatorStyle =
-          helpers.defaultNullOpts.mkEnum ["slant" "thick" "thin"] "thin"
+          helpers.defaultNullOpts.mkEnum ["slant" "padded_slant" "slope" "padded_slope" "thick" "thin"] "thin"
           "Separator style";
 
         nameFormatter =


### PR DESCRIPTION
This adds the additional `bufferline` tab-styles as options.

```:h bufferline-styling```
```shell
==============================================================================
STYLING                                                  *bufferline-styling*

You can change the appearance of the bufferline separators by setting the
`separator_style`. The available options are:
* `slant` - Use slanted/triangular separators
* `padded_slant` - Same as `slant` but with extra padding which some terminals require.
  If `slant` does not render correctly for you try padded this instead.
* `slope` - Use slanted/triangular separators but slopped to the right
* `padded_slope` - Same as `slope` but with extra padding which some terminals require.
  If `slope` does not render correctly for you try padded this instead.
* `thick` - Increase the thickness of the separator characters
* `thin` - (default) Use thin separator characters
* finally you can pass in a custom list containing 2 characters which will be
  used as the separators e.g. `{"|", "|"}`, the first is the left and the
  second is the right separator

==============================================================================
```