### PR TITLE
plugins/treesitter: add parsersToFiletypes option

### DIFF
--- a/tests/test-sources/plugins/languages/treesitter/treesitter.nix
+++ b/tests/test-sources/plugins/languages/treesitter/treesitter.nix
@@ -16,6 +16,11 @@
     plugins.treesitter = {
       enable = true;
       nixvimInjections = true;
+
+      languageRegister = {
+        cpp = "onelab";
+        python = ["foo" "bar"];
+      };
     };
   };
 


### PR DESCRIPTION
Add a wrapper option to the `vim.treesitter.language.register` option.
This allows to map specific parsers to one or more filetypes.

I don't know if the name I chose (`parsersToFiletypes`) is a good idea.
I thought about `register`, but it is more adpated to a function name (an action) rather than this option which allows to do several _registrations_ (i.e. an attrs).