### PR TITLE
plugins/nvim-lsp: add java language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -172,6 +172,12 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/vscode-html-language-server" "--stdio"];
     }
     {
+      name = "java-language-server";
+      description = "Enable java language server";
+      serverName = "java_language_server";
+      cmd = cfg: ["${cfg.package}/bin/java-language-server"];
+    }
+    {
       name = "jsonls";
       description = "Enable jsonls, for JSON";
       package = pkgs.nodePackages.vscode-langservers-extracted;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -78,6 +78,7 @@
         gopls.enable = true;
         hls.enable = true;
         html.enable = true;
+        java-language-server.enable = true;
         jsonls.enable = true;
         julials.enable = true;
         ltex.enable = true;


### PR DESCRIPTION
Add [`java`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#java_language_server) language server.

This throws an error in my config:
```shell
Error executing vim.schedule lua callback: ...rapped-0.9.1/share/nvim/runtime/lua/vim/lsp/handlers.lua:122: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
    [C]: in function 'ipairs'
    ...rapped-0.9.1/share/nvim/runtime/lua/vim/lsp/handlers.lua:122: in function 'handler'
    ...eovim-unwrapped-0.9.1/share/nvim/runtime/lua/vim/lsp.lua:1057: in function ''
    vim/_editor.lua: in funvtion <vim/_editor.lua:0>
```

But the language server still works and I don't think it's related to the PR.
