### PR TITLE
plugins/cursorline: init + test

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -78,6 +78,7 @@
     ./utils/comment-nvim.nix
     ./utils/commentary.nix
     ./utils/conjure.nix
+    ./utils/cursorline.nix
     ./utils/easyescape.nix
     ./utils/endwise.nix
     ./utils/floaterm.nix

--- a/plugins/utils/cursorline.nix
+++ b/plugins/utils/cursorline.nix
@@ -1,0 +1,65 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.cursorline;
+  helpers = import ../helpers.nix {inherit lib;};
+in {
+  options.plugins.cursorline =
+    helpers.extraOptionsOptions
+    // {
+      enable = mkEnableOption "nvim-cursorline";
+
+      package = helpers.mkPackageOption "nvim-cursorline" pkgs.vimPlugins.nvim-cursorline;
+
+      cursorline = {
+        enable =
+          helpers.defaultNullOpts.mkBool true
+          "Show / hide cursorline in connection with cursor moving.";
+
+        timeout =
+          helpers.defaultNullOpts.mkInt 1000
+          "Time (in ms) after which the cursorline appears.";
+
+        number =
+          helpers.defaultNullOpts.mkBool false
+          "Whether to also highlight the line number.";
+      };
+      cursorword = {
+        enable = helpers.defaultNullOpts.mkBool true "Underlines the word under the cursor.";
+
+        minLength = helpers.defaultNullOpts.mkInt 3 "Minimum length for underlined words.";
+
+        hl =
+          helpers.defaultNullOpts.mkNullable
+          types.attrs
+          "{underline = true;}"
+          "Highliht definition map for cursorword highlighting.";
+      };
+    };
+
+  config = let
+    options =
+      {
+        cursorline = with cfg.cursorline; {
+          inherit enable timeout number;
+        };
+        cursorword = with cfg.cursorword; {
+          inherit enable;
+          min_length = minLength;
+          inherit hl;
+        };
+      }
+      // cfg.extraOptions;
+  in
+    mkIf cfg.enable {
+      extraPlugins = [cfg.package];
+
+      extraConfigLua = ''
+        require('nvim-cursorline').setup(${helpers.toLuaObject options})
+      '';
+    };
+}

--- a/tests/test-sources/plugins/utils/cursorline.nix
+++ b/tests/test-sources/plugins/utils/cursorline.nix
@@ -1,0 +1,24 @@
+{
+  empty = {
+    plugins.cursorline.enable = true;
+  };
+
+  defaults = {
+    plugins.cursorline = {
+      enable = true;
+
+      cursorline = {
+        enable = true;
+        timeout = 1000;
+        number = false;
+      };
+      cursorword = {
+        enable = true;
+        minLength = 3;
+        hl = {
+          underline = true;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for the [`nvim-cursorline`](https://github.com/yamatsum/nvim-cursorline) plugin.

Fixes #422.