### PR TITLE
plugins/nvim-cmp: fix crates-nvim source plugin

### DIFF
--- a/plugins/completion/nvim-cmp/sources/crates-nvim.nix
+++ b/plugins/completion/nvim-cmp/sources/crates-nvim.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.crates-nvim;
+  helpers = import ../../../helpers.nix {inherit lib;};
+in {
+  options.plugins.crates-nvim = helpers.extraOptionsOptions;
+
+  config = mkIf cfg.enable {
+    extraConfigLua = ''
+      require('crates').setup(${helpers.toLuaObject cfg.extraOptions})
+    '';
+  };
+}

--- a/plugins/completion/nvim-cmp/sources/default.nix
+++ b/plugins/completion/nvim-cmp/sources/default.nix
@@ -12,6 +12,7 @@ in {
   imports =
     [
       ./cmp-tabnine.nix
+      ./crates-nvim.nix
     ]
     ++ pluginModules;
 }


### PR DESCRIPTION
The `crates-nvim` which provides the `crates` source for `nvim-cmp` requires its `setup` function to be called.

Fixes #425 