### PR TITLE
plugins/lsp: add nixd language server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,15 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    beautysh.url = "github:lovesegfault/beautysh";
-    beautysh.inputs.nixpkgs.follows = "nixpkgs";
+    beautysh = {
+      url = "github:lovesegfault/beautysh";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
-    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -310,6 +310,53 @@ with lib; let
       settings = cfg: {nil = {inherit (cfg) formatting diagnostics;};};
     }
     {
+      name = "nixd";
+      description = "Enable nixd, for Nix";
+      package = pkgs.nixd;
+      settings = cfg: {nixd = cfg;};
+      settingsOptions = {
+        # The evaluation section, provide auto completion for dynamic bindings.
+        eval = {
+          target = {
+            args = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+              Accept args as "nix eval".
+            '';
+
+            installable = helpers.defaultNullOpts.mkStr "" ''
+              "nix eval"
+            '';
+          };
+
+          depth = helpers.defaultNullOpts.mkInt 0 "Extra depth for evaluation";
+
+          workers = helpers.defaultNullOpts.mkInt 3 "The number of workers for evaluation task.";
+        };
+
+        formatting = {
+          command = helpers.defaultNullOpts.mkStr "nixpkgs-fmt" ''
+            Which command you would like to do formatting
+          '';
+        };
+
+        options = {
+          enable = helpers.defaultNullOpts.mkBool true ''
+            Enable option completion task.
+            If you are writting a package, disable this
+          '';
+
+          target = {
+            args = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+              Accept args as "nix eval".
+            '';
+
+            installable = helpers.defaultNullOpts.mkStr "" ''
+              "nix eval"
+            '';
+          };
+        };
+      };
+    }
+    {
       name = "pylsp";
       description = "Enable pylsp, for Python.";
       package = pkgs.python3Packages.python-lsp-server;

--- a/tests/test-sources/plugins/lsp/nixd.nix
+++ b/tests/test-sources/plugins/lsp/nixd.nix
@@ -1,0 +1,35 @@
+{pkgs}: {
+  example = {
+    plugins.lsp = {
+      enable = true;
+
+      servers.nixd = {
+        # TODO nixd is currently broken on Darwin
+        # https://github.com/nix-community/nixd/issues/107
+        # Thus, this test is currently disabled.
+        enable = !pkgs.stdenv.isDarwin;
+
+        settings = {
+          eval = {
+            target = {
+              args = ["foo" "bar"];
+              installable = "";
+            };
+            depth = 0;
+            workers = 3;
+          };
+          formatting = {
+            command = "nixpkgs-fmt";
+          };
+          options = {
+            enable = true;
+            target = {
+              args = ["yes" "no" "maybe"];
+              installable = "";
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -1,4 +1,4 @@
-{
+{pkgs}: {
   empty = {
     plugins.lsp.enable = true;
   };
@@ -87,6 +87,10 @@
         lua-ls.enable = true;
         metals.enable = true;
         nil_ls.enable = true;
+        # TODO nixd is currently broken on Darwin
+        # https://github.com/nix-community/nixd/issues/107
+        # Thus, this test is currently disabled.
+        nixd.enable = !pkgs.stdenv.isDarwin;
         pylsp.enable = true;
         pyright.enable = true;
         rnix-lsp.enable = true;


### PR DESCRIPTION
Add support for the [`nixd`](https://github.com/nix-community/nixd) language server.

~~It required propagating the flake's inputs to the module and the doc.~~
A [PR](https://github.com/NixOS/nixpkgs/pull/236675) has been made to package `nixd` directly in nixpkgs.
--> Let's wait for it to be merged so that we do not have to propagate the flake's inputs.