### PR TITLE
plugins/noice: turn routes into a list

### DIFF
--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -264,7 +264,7 @@ in {
       '';
 
       views = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
-      routes = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
+      routes = helpers.defaultNullOpts.mkNullable (types.listOf (types.attrsOf types.anything)) "[]" "";
       status = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
       format = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
     };

--- a/tests/test-sources/plugins/ui/noice.nix
+++ b/tests/test-sources/plugins/ui/noice.nix
@@ -200,7 +200,7 @@
       };
       throttle = 1000 / 30;
       views = {};
-      routes = {};
+      routes = [];
       status = {};
       format = {};
     };


### PR DESCRIPTION
Judging by [the routes example in noice readme](https://github.com/folke/noice.nvim#-routes) and by [`route.lua` using `list_extend` on it](https://github.com/folke/noice.nvim/blob/a3318600bc1eba2cca84e879048c1ab8d4a0262d/lua/noice/config/routes.lua#L13), it seems to me that `plugins.noice.routes` is supposed to be a list.