### PR TITLE
helpers.defaultNullOpts: add mkBorder

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -144,10 +144,19 @@ with lib; rec {
     mkEnum = enum: default: mkNullable (lib.types.enum enum) ''"${default}"'';
     mkEnumFirstDefault = enum: mkEnum enum (head enum);
     mkBorder = default: name: desc:
-      mkNullable (with lib.types; oneOf [str (listOf str) (listOf (listOf str))]) default (let
+      mkNullable
+      (
+        with lib.types;
+          oneOf [
+            str
+            (listOf str)
+            (listOf (listOf str))
+          ]
+      )
+      default
+      (let
         defaultDesc = ''
           Defines the border to use for ${name}.
-
           Accepts same border values as `nvim_open_win()`. See `:help nvim_open_win()` for more info.
         '';
       in
@@ -155,7 +164,6 @@ with lib; rec {
         then defaultDesc
         else ''
           ${desc}
-
           ${defaultDesc}
         '');
   };

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -143,6 +143,21 @@ with lib; rec {
     mkStr = default: mkNullable lib.types.str ''${builtins.toString default}'';
     mkEnum = enum: default: mkNullable (lib.types.enum enum) ''"${default}"'';
     mkEnumFirstDefault = enum: mkEnum enum (head enum);
+    mkBorder = default: name: desc:
+      mkNullable (with lib.types; oneOf [str (listOf str) (listOf (listOf str))]) default (let
+        defaultDesc = ''
+          Defines the border to use for ${name}.
+
+          Accepts same border values as `nvim_open_win()`. See `:help nvim_open_win()` for more info.
+        '';
+      in
+        if desc == ""
+        then defaultDesc
+        else ''
+          ${desc}
+
+          ${defaultDesc}
+        '');
   };
 
   mkPackageOption = name: default:

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -391,15 +391,6 @@ in {
 
     window = let
       # Reusable options
-      mkBorderOption = default:
-        helpers.defaultNullOpts.mkNullable
-        (with types; either str (listOf str))
-        default
-        ''
-          Border characters used for the completion popup menu when |experimental.native_menu| is disabled.
-          See |nvim_open_win|.
-        '';
-
       mkWinhighlightOption = default:
         helpers.defaultNullOpts.mkStr
         default
@@ -415,7 +406,7 @@ in {
     in
       helpers.mkCompositeOption "Windows options" {
         completion = helpers.mkCompositeOption "Completion window options" {
-          border = mkBorderOption ''[ "" "" "" "" "" "" "" "" ]'';
+          border = helpers.defaultNullOpts.mkBorder ''[ "" "" "" "" "" "" "" "" ]'' "nvim-cmp window" "";
 
           winhighlight =
             mkWinhighlightOption
@@ -442,7 +433,7 @@ in {
         };
 
         documentation = helpers.mkCompositeOption "Documentation window options" {
-          border = mkBorderOption ''[ "" "" "" " " "" "" "" " " ]'';
+          border = helpers.defaultNullOpts.mkBorder ''[ "" "" "" " " "" "" "" " " ]'' "nvim-cmp documentation window" "";
 
           winhighlight = mkWinhighlightOption "FloatBorder:NormalFloat";
 

--- a/plugins/languages/clangd-extensions.nix
+++ b/plugins/languages/clangd-extensions.nix
@@ -7,12 +7,7 @@
   helpers = import ../helpers.nix {inherit lib;};
 in
   with lib; let
-    borderOpt = let
-      bordersTy =
-        types.enum ["double" "rounded" "single" "shadow" "none"];
-    in
-      helpers.defaultNullOpts.mkNullable (types.either bordersTy (types.listOf bordersTy))
-      ''"none"'' "";
+    borderOpt = helpers.defaultNullOpts.mkBorder "none" "clangd-extensions" "";
   in {
     options.plugins.clangd-extensions = {
       enable = mkEnableOption "clangd_extensions, plugin implementing clangd LSP extensions";

--- a/plugins/languages/rust.nix
+++ b/plugins/languages/rust.nix
@@ -73,8 +73,7 @@ in {
 
       hoverActions = helpers.mkCompositeOption "hover actions" {
         border =
-          helpers.defaultNullOpts.mkNullable (types.listOf (types.listOf types.str))
-          ''
+          helpers.defaultNullOpts.mkBorder ''
             [
               [ "╭" "FloatBorder" ]
               [ "─" "FloatBorder" ]
@@ -86,7 +85,7 @@ in {
               [ "│" "FloatBorder" ]
             ]
           ''
-          "the border that is used for the hover window. see vim.api.nvim_open_win()";
+          "rust-tools hover window" "";
 
         maxWidth =
           helpers.defaultNullOpts.mkNullable types.int "null"

--- a/plugins/languages/sniprun.nix
+++ b/plugins/languages/sniprun.nix
@@ -118,9 +118,7 @@ in {
         helpers.defaultNullOpts.mkStr "off"
         "Live mode toggle, see Usage - Running for more info.";
 
-      borders =
-        helpers.defaultNullOpts.mkEnum ["none" "single" "double" "shadow"] "single"
-        "Display borders around floating windows.";
+      borders = helpers.defaultNullOpts.mkBorder "single" "floating windows" "";
     };
 
   config = mkIf cfg.enable {

--- a/plugins/null-ls/default.nix
+++ b/plugins/null-ls/default.nix
@@ -23,10 +23,8 @@ in {
         description = "Plugin to use for null-ls";
       };
 
-      border = helpers.defaultNullOpts.mkStr "null" ''
-        Defines the border to use for the `:NullLsInfo` UI window.
+      border = helpers.defaultNullOpts.mkBorder "null" "`:NullLsInfo` UI window." ''
         Uses `NullLsInfoBorder` highlight group (see [Highlight Groups](#highlight-groups)).
-        Accepts same border values as `nvim_open_win()`. See `:help nvim_open_win()` for more info.
       '';
 
       cmd = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["nvim"]'' ''

--- a/plugins/utils/nvim-ufo.nix
+++ b/plugins/utils/nvim-ufo.nix
@@ -41,9 +41,7 @@ in {
 
       preview = {
         winConfig = {
-          border =
-            helpers.defaultNullOpts.mkNullable (types.either types.str (types.listOf types.str)) "rounded"
-            "The border for preview window, `:h nvim_open_win() | call search('border:')`";
+          border = helpers.defaultNullOpts.mkBorder "rounded" "preview window" "";
 
           winblend = helpers.defaultNullOpts.mkInt 12 "The winblend for preview window, `:h winblend`";
 

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -52,7 +52,7 @@ with lib; let
       helpers.mkNullOrOption (with types; either int fractionType)
       "Optionally define an integer/float for the exact height of the preview window.";
 
-    border = helpers.defaultNullOpts.mkStr "rounded" "";
+    border = helpers.defaultNullOpts.mkBorder "rounded" "oil" "";
 
     winOptions = {
       winblend = helpers.defaultNullOpts.mkInt 0 "";
@@ -315,7 +315,7 @@ in {
 
         maxHeight = helpers.defaultNullOpts.mkInt 0 "";
 
-        border = helpers.defaultNullOpts.mkStr "rounded" "";
+        border = helpers.defaultNullOpts.mkBorder "rounded" "oil.open_float" "";
 
         winOptions = {
           winblend = helpers.defaultNullOpts.mkInt 10 "";
@@ -329,7 +329,7 @@ in {
       progress =
         commonWindowOptions
         // {
-          minimizedBorder = helpers.defaultNullOpts.mkStr "none" "";
+          minimizedBorder = helpers.defaultNullOpts.mkBorder "none" "oil floating progress window" "";
         };
     };
 

--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -140,13 +140,12 @@ in {
 
     floatOpts = {
       border =
-        helpers.defaultNullOpts.mkStr "single"
+        helpers.defaultNullOpts.mkBorder "single" "toggleterm"
         ''
           `border` = 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by
           `win open`.
           The border key is *almost* the same as 'nvim_open_win'.
-          See `:h nvim_open_win` for details on borders however the 'curved' border is a custom
-          border type not natively supported but implemented in this plugin.
+          The 'curved' border is a custom border type not natively supported but implemented in this plugin.
         '';
 
       width = helpers.defaultNullOpts.mkInt 50 "";

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -81,7 +81,7 @@ in {
         };
       };
     in {
-      border = helpers.defaultNullOpts.mkEnumFirstDefault ["none" "single" "double" "shadow"] "";
+      border = helpers.defaultNullOpts.mkBorder "none" "which-key" "";
       position = helpers.defaultNullOpts.mkEnumFirstDefault ["bottom" "top"] "";
       margin =
         helpers.defaultNullOpts.mkNullable spacingOptions


### PR DESCRIPTION
Introduced a new helper function called `mkBorder` that simplifies the process of creating border options for plugins that use `nvim_open_win`.