### PR TITLE
plugins/nvim-lsp: add cmake LS

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -35,6 +35,11 @@ with lib; let
       package = pkgs.clojure-lsp;
     }
     {
+      name = "cmake";
+      description = "Enable cmake language server, for cmake files.";
+      package = pkgs.cmake-language-server;
+    }
+    {
       name = "cssls";
       description = "Enable cssls, for CSS";
       package = pkgs.vscode-langservers-extracted;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -70,6 +70,7 @@
         ccls.enable = true;
         clangd.enable = true;
         clojure-lsp.enable = true;
+        cmake.enable = true;
         cssls.enable = true;
         dartls.enable = true;
         denols.enable = true;


### PR DESCRIPTION
Add support for the [cmake language server](https://github.com/regen100/cmake-language-server).

Fixes #450.