### PR TITLE
plugins/nvim-lsp: enable now working nixd tests on darwin 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687502512,
-        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
+        "lastModified": 1687807295,
+        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
+        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1687251716,
-        "narHash": "sha256-+sFS41thsB5U+lY/dBYPSmU4AJ7nz/VdM1WD35fXVeM=",
+        "lastModified": 1687779420,
+        "narHash": "sha256-noueZE/Z5qx6NF/grg46qlpZ/1nuPpc92RvqgCmRaLI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7807e1851d95828ed98491930d2d9e7ddbe65da4",
+        "rev": "1fa438eee82f35bdd4bc30a9aacd7648d757b388",
         "type": "github"
       },
       "original": {

--- a/tests/test-sources/plugins/lsp/nixd.nix
+++ b/tests/test-sources/plugins/lsp/nixd.nix
@@ -4,10 +4,7 @@
       enable = true;
 
       servers.nixd = {
-        # TODO nixd is currently broken on Darwin
-        # https://github.com/nix-community/nixd/issues/107
-        # Thus, this test is currently disabled.
-        enable = !pkgs.stdenv.isDarwin;
+        enable = true;
 
         settings = {
           eval = {

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -88,10 +88,7 @@
         lua-ls.enable = true;
         metals.enable = true;
         nil_ls.enable = true;
-        # TODO nixd is currently broken on Darwin
-        # https://github.com/nix-community/nixd/issues/107
-        # Thus, this test is currently disabled.
-        nixd.enable = !pkgs.stdenv.isDarwin;
+        nixd.enable = true;
         pylsp.enable = true;
         pyright.enable = true;
         rnix-lsp.enable = true;


### PR DESCRIPTION
`nixd` is now working properly on darwin.