### PR TITLE
plugins/neorg: refactor + test + neorg-telescope

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687807295,
-        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1687779420,
-        "narHash": "sha256-noueZE/Z5qx6NF/grg46qlpZ/1nuPpc92RvqgCmRaLI=",
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1fa438eee82f35bdd4bc30a9aacd7648d757b388",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
         "type": "github"
       },
       "original": {

--- a/tests/test-sources/plugins/utils/neorg.nix
+++ b/tests/test-sources/plugins/utils/neorg.nix
@@ -1,0 +1,75 @@
+{
+  empty = {
+    plugins.neorg.enable = true;
+  };
+
+  example = {
+    plugins = {
+      # Treesitter is required when using the "core.defaults" module.
+      treesitter.enable = true;
+
+      neorg = {
+        enable = true;
+
+        lazyLoading = false;
+        logger = {
+          plugin = "neorg";
+          useConsole = true;
+          highlights = true;
+          useFile = true;
+          level = "warn";
+          modes = {
+            trace = {
+              hl = "Comment";
+              level = "trace";
+            };
+            debug = {
+              hl = "Comment";
+              level = "debug";
+            };
+            info = {
+              hl = "None";
+              level = "info";
+            };
+            warn = {
+              hl = "WarningMsg";
+              level = "warn";
+            };
+            error = {
+              hl = "ErrorMsg";
+              level = "error";
+            };
+            fatal = {
+              hl = "ErrorMsg";
+              level = 5;
+            };
+          };
+          floatPrecision = 0.01;
+        };
+
+        modules = {
+          "core.defaults" = {__empty = null;};
+          "core.dirman" = {
+            config = {
+              workspaces = {
+                work = "~/notes/work";
+                home = "~/notes/home";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  telescope-integration = {
+    plugins = {
+      telescope.enable = false;
+
+      neorg = {
+        enable = false;
+        modules."core.integrations.telescope".__empty = null;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Some changes on the `neorg` plugin:
- Some refactors that have no impact on the end user
- Add testing
- Add support for plugin/neorg module [`neorg-telescope`](https://github.com/nvim-neorg/neorg-telescope)