### PR TITLE
plugins/null-ls: added support for multiple new sources

### DIFF
--- a/plugins/null-ls/servers.nix
+++ b/plugins/null-ls/servers.nix
@@ -35,6 +35,30 @@
       statix = {
         package = pkgs.statix;
       };
+      vale = {
+        package = pkgs.vale;
+      };
+      vulture = {
+        package = pkgs.python3Packages.vulture;
+      };
+      alex = {
+        package = pkgs.nodePackages.alex;
+      };
+      protolint = {
+        package = pkgs.protolint;
+      };
+      hadolint = {
+        package = pkgs.hadolint;
+      };
+      luacheck = {
+        package = pkgs.luaPackages.luacheck;
+      };
+      mypy = {
+        package = pkgs.mypy;
+      };
+      pylint = {
+        package = pkgs.pylint;
+      };
     };
     formatting = {
       phpcbf = {
@@ -72,6 +96,24 @@
       };
       taplo = {
         package = pkgs.taplo;
+      };
+      isort = {
+        package = pkgs.isort;
+      };
+      jq = {
+        package = pkgs.jq;
+      };
+      markdownlint = {
+        package = pkgs.nodePackages.markdownlint-cli;
+      };
+      protolint = {
+        package = pkgs.protolint;
+      };
+      rustfmt = {
+        package = pkgs.rustfmt;
+      };
+      sqlfluff = {
+        package = pkgs.sqlfluff;
       };
     };
   };

--- a/plugins/null-ls/servers.nix
+++ b/plugins/null-ls/servers.nix
@@ -17,35 +17,20 @@
     };
     completion = {};
     diagnostics = {
-      flake8 = {
-        package = pkgs.python3Packages.flake8;
-      };
-      shellcheck = {
-        package = pkgs.shellcheck;
+      alex = {
+        package = pkgs.nodePackages.alex;
       };
       cppcheck = {
         package = pkgs.cppcheck;
       };
-      gitlint = {
-        package = pkgs.gitlint;
-      };
       deadnix = {
         package = pkgs.deadnix;
       };
-      statix = {
-        package = pkgs.statix;
+      flake8 = {
+        package = pkgs.python3Packages.flake8;
       };
-      vale = {
-        package = pkgs.vale;
-      };
-      vulture = {
-        package = pkgs.python3Packages.vulture;
-      };
-      alex = {
-        package = pkgs.nodePackages.alex;
-      };
-      protolint = {
-        package = pkgs.protolint;
+      gitlint = {
+        package = pkgs.gitlint;
       };
       hadolint = {
         package = pkgs.hadolint;
@@ -56,46 +41,40 @@
       mypy = {
         package = pkgs.mypy;
       };
+      protolint = {
+        package = pkgs.protolint;
+      };
       pylint = {
         package = pkgs.pylint;
       };
+      shellcheck = {
+        package = pkgs.shellcheck;
+      };
+      statix = {
+        package = pkgs.statix;
+      };
+      vale = {
+        package = pkgs.vale;
+      };
+      vulture = {
+        package = pkgs.python3Packages.vulture;
+      };
     };
     formatting = {
-      phpcbf = {
-        package = pkgs.phpPackages.phpcbf;
-      };
       alejandra = {
         package = pkgs.alejandra;
-      };
-      nixfmt = {
-        package = pkgs.nixfmt;
-      };
-      nixpkgs_fmt = {
-        package = pkgs.nixpkgs-fmt;
-      };
-      prettier = {
-        package = pkgs.nodePackages.prettier;
       };
       black = {
         package = pkgs.python3Packages.black;
       };
-      fourmolu = {
-        package = pkgs.haskellPackages.fourmolu;
+      cbfmt = {
+        package = pkgs.cbfmt;
       };
       fnlfmt = {
         package = pkgs.fnlfmt;
       };
-      stylua = {
-        package = pkgs.stylua;
-      };
-      cbfmt = {
-        package = pkgs.cbfmt;
-      };
-      shfmt = {
-        package = pkgs.shfmt;
-      };
-      taplo = {
-        package = pkgs.taplo;
+      fourmolu = {
+        package = pkgs.haskellPackages.fourmolu;
       };
       isort = {
         package = pkgs.isort;
@@ -106,14 +85,35 @@
       markdownlint = {
         package = pkgs.nodePackages.markdownlint-cli;
       };
+      nixfmt = {
+        package = pkgs.nixfmt;
+      };
+      nixpkgs_fmt = {
+        package = pkgs.nixpkgs-fmt;
+      };
+      phpcbf = {
+        package = pkgs.phpPackages.phpcbf;
+      };
+      prettier = {
+        package = pkgs.nodePackages.prettier;
+      };
       protolint = {
         package = pkgs.protolint;
       };
       rustfmt = {
         package = pkgs.rustfmt;
       };
+      shfmt = {
+        package = pkgs.shfmt;
+      };
       sqlfluff = {
         package = pkgs.sqlfluff;
+      };
+      stylua = {
+        package = pkgs.stylua;
+      };
+      taplo = {
+        package = pkgs.taplo;
       };
     };
   };

--- a/tests/test-sources/plugins/null-ls.nix
+++ b/tests/test-sources/plugins/null-ls.nix
@@ -47,6 +47,14 @@
           shellcheck.enable = true;
           statix.enable = true;
           deadnix.enable = true;
+          vale.enable = true;
+          vulture.enable = true;
+          alex.enable = true;
+          protolint.enable = true;
+          hadolint.enable = true;
+          luacheck.enable = true;
+          mypy.enable = true;
+          pylint.enable = true;
         };
         formatting = {
           alejandra.enable = true;
@@ -61,6 +69,12 @@
           stylua.enable = true;
           taplo.enable = true;
           nixpkgs_fmt.enable = true;
+          isort.enable = true;
+          jq.enable = true;
+          markdownlint.enable = true;
+          protolint.enable = true;
+          rustfmt.enable = true;
+          sqlfluff.enable = true;
         };
       };
     };


### PR DESCRIPTION
Added support for following new sources in null-ls:
Diagnostics:
- vale
- vulture
- alex
- protolint
- hadolint
- luacheck
- mypy
- pylint

Formatting:
- isort
- jq
- markdownlint
- protolint
- rustfmt
- sqlfluff