### PR TITLE
plugins/nvim-lsp: add csharp-ls language server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688231357,
-        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
+        "lastModified": 1688500189,
+        "narHash": "sha256-djYYiY4lzJOlXOnTHytH6BUugrxHDZjuGxTSrU4gt4M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
+        "rev": "78419edadf0fabbe5618643bd850b2f2198ed060",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1688137124,
-        "narHash": "sha256-ramG4s/+A5+t/QG2MplTNPP/lmBWDtbW6ilpwb9sKVo=",
+        "lastModified": 1688473851,
+        "narHash": "sha256-j+ViA3lh4uQGIDqB6TjM4+wijX2M5mfNb6MVJVekpAs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "522fd47af79b66cdd04b92618e65c7a11504650a",
+        "rev": "f6a6863a3bcb61e846a9e4777b90ee365607a925",
         "type": "github"
       },
       "original": {

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -40,6 +40,12 @@ with lib; let
       package = pkgs.cmake-language-server;
     }
     {
+      name = "csharp-ls";
+      description = "Enable csharp-ls, for C#.";
+      package = pkgs.csharp-ls;
+      serverName = "csharp_ls";
+    }
+    {
       name = "cssls";
       description = "Enable cssls, for CSS";
       package = pkgs.vscode-langservers-extracted;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -71,6 +71,8 @@
         clangd.enable = true;
         clojure-lsp.enable = true;
         cmake.enable = true;
+        # pkgs.csharp-ls only supports linux platforms
+        csharp-ls.enable = pkgs.stdenv.isLinux;
         cssls.enable = true;
         dartls.enable = true;
         denols.enable = true;


### PR DESCRIPTION
Add support for the [csharp-ls](https://github.com/razzmatazz/csharp-language-server) language server.

~~We have to wait for https://github.com/NixOS/nixpkgs/pull/241185 to make its way to `nixos-unstable`.
Status: https://nixpk.gs/pr-tracker.html?pr=241185~~