### PR TITLE
plugins/colorschemes/oxocarbon: init

### DIFF
--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -21,7 +21,7 @@ in {
     extraPlugins = [cfg.package];
 
     options = {
-      termguicolors = true;
+      termguicolors = mkDefault true;
     };
   };
 }

--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -12,7 +12,7 @@ in {
     colorschemes.oxocarbon = {
       enable = mkEnableOption "oxocarbon";
 
-      package = helpers.mkPackageOption "one" pkgs.vimPlugins.oxocarbon-nvim;
+      package = helpers.mkPackageOption "oxocarbon" pkgs.vimPlugins.oxocarbon-nvim;
     };
   };
 

--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.colorschemes.oxocarbon;
+  helpers = import ../helpers.nix {inherit lib;};
+in {
+  options = {
+    colorschemes.oxocarbon = {
+      enable = mkEnableOption "oxocarbon";
+
+      package = helpers.mkPackageOption "one" pkgs.vimPlugins.oxocarbon-nvim;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    colorscheme = "oxocarbon";
+    extraPlugins = [cfg.package];
+
+    options = {
+      termguicolors = true;
+    };
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -9,6 +9,7 @@
     ./colorschemes/nord.nix
     ./colorschemes/one.nix
     ./colorschemes/onedark.nix
+    ./colorschemes/oxocarbon.nix
     ./colorschemes/poimandres.nix
     ./colorschemes/tokyonight.nix
     ./colorschemes/catppuccin.nix

--- a/tests/test-sources/plugins/colorschemes/oxocarbon.nix
+++ b/tests/test-sources/plugins/colorschemes/oxocarbon.nix
@@ -2,4 +2,4 @@
   empty = {
     colorschemes.oxocarbon.enable = true;
   };
-
+}

--- a/tests/test-sources/plugins/colorschemes/oxocarbon.nix
+++ b/tests/test-sources/plugins/colorschemes/oxocarbon.nix
@@ -1,0 +1,10 @@
+{
+  empty = {colorschemes.oxocarbon.enable = true;};
+
+  # All the upstream default options of oxocarbon
+  defaults = {
+    colorschemes.oxocarbon = {
+      enable = true;
+    };
+  };
+}

--- a/tests/test-sources/plugins/colorschemes/oxocarbon.nix
+++ b/tests/test-sources/plugins/colorschemes/oxocarbon.nix
@@ -1,10 +1,3 @@
 {
   empty = {colorschemes.oxocarbon.enable = true;};
 
-  # All the upstream default options of oxocarbon
-  defaults = {
-    colorschemes.oxocarbon = {
-      enable = true;
-    };
-  };
-}

--- a/tests/test-sources/plugins/colorschemes/oxocarbon.nix
+++ b/tests/test-sources/plugins/colorschemes/oxocarbon.nix
@@ -1,3 +1,5 @@
 {
-  empty = {colorschemes.oxocarbon.enable = true;};
+  empty = {
+    colorschemes.oxocarbon.enable = true;
+  };
 


### PR DESCRIPTION
Added support for the oxocarbon-nvim colorscheme.

Homepage: https://github.com/nyoom-engineering/oxocarbon.nvim

I have tested and formatted my code.