### PR TITLE
plugins/nvim-lsp: add elm-language-server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -149,7 +149,7 @@ with lib; let
     }
     {
       name = "elmls";
-      description = "Enable the Elm Language Server";
+      description = "Enable elmls, for Elm.";
       package = pkgs.elmPackages.elm-language-server;
     }
     {

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -148,6 +148,11 @@ with lib; let
       package = pkgs.deno;
     }
     {
+      name = "elmls";
+      description = "Enable the Elm Language Server";
+      package = pkgs.elmPackages.elm-language-server;
+    }
+    {
       name = "eslint";
       description = "Enable eslint";
       package = pkgs.vscode-langservers-extracted;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -76,6 +76,7 @@
         cssls.enable = true;
         dartls.enable = true;
         denols.enable = true;
+        elmls.enable = true;
         eslint.enable = true;
         elixirls.enable = true;
         futhark-lsp.enable = true;


### PR DESCRIPTION
adds config for enabling the Elm language server