### PR TITLE
colorschemes/catpuccin: fix type for option colorOverrides

### DIFF
--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -7,6 +7,13 @@
 with lib; let
   cfg = config.colorschemes.catppuccin;
   helpers = import ../helpers.nix args;
+
+  flavours = [
+    "latte"
+    "mocha"
+    "frappe"
+    "macchiato"
+  ];
 in {
   options = {
     colorschemes.catppuccin = {
@@ -15,21 +22,11 @@ in {
       package =
         helpers.mkPackageOption "catppuccin" pkgs.vimPlugins.catppuccin-nvim;
 
-      flavour = helpers.defaultNullOpts.mkEnumFirstDefault [
-        "latte"
-        "mocha"
-        "frappe"
-        "macchiato"
-      ] "Theme flavour";
+      flavour = helpers.defaultNullOpts.mkEnumFirstDefault flavours "Theme flavour";
 
       background = let
         mkBackgroundStyle = name:
-          helpers.defaultNullOpts.mkEnumFirstDefault [
-            "latte"
-            "mocha"
-            "frappe"
-            "macchiato"
-          ] "Background for ${name}";
+          helpers.defaultNullOpts.mkEnumFirstDefault flavours "Background for ${name}";
       in {
         light = mkBackgroundStyle "light";
         dark = mkBackgroundStyle "dark";
@@ -115,23 +112,20 @@ in {
           "Define operators highlight properties";
       };
 
-      colorOverrides = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) "{}" ''
-        Define color overrides
-        Example:
-         color_overrides = {
-             all = {
-                 text = "#ffffff",
-             },
-             latte = {
-                 base = "#ff0000",
-                 mantle = "#242424",
-                 crust = "#474747",
-             },
-             frappe = {},
-             macchiato = {},
-             mocha = {},
-         }
-      '';
+      colorOverrides =
+        genAttrs
+        (flavours ++ ["all"])
+        (
+          flavour:
+            helpers.defaultNullOpts.mkNullable
+            (with types; attrsOf str)
+            "{}"
+            (
+              if flavour == "all"
+              then "Override colors for all of the flavours."
+              else "Override colors for the ${flavour} flavour."
+            )
+        );
 
       customHighlights =
         helpers.defaultNullOpts.mkNullable

--- a/tests/test-sources/plugins/colorschemes/catppuccin.nix
+++ b/tests/test-sources/plugins/colorschemes/catppuccin.nix
@@ -1,6 +1,8 @@
 {
   # Empty configuration
-  empty = {colorschemes.catppuccin.enable = true;};
+  empty = {
+    colorschemes.catppuccin.enable = true;
+  };
 
   # All the upstream default options of poimandres
   defaults = {
@@ -44,6 +46,46 @@
         telescope = true;
         notify = false;
         mini = false;
+      };
+    };
+  };
+
+  example = {
+    colorschemes.catppuccin = {
+      enable = true;
+
+      flavour = "mocha";
+      terminalColors = true;
+      colorOverrides.mocha.base = "#1e1e2f";
+
+      integrations = {
+        barbar = true;
+        fidget = true;
+        gitsigns = true;
+        illuminate = true;
+        indent_blankline = {
+          enabled = true;
+          colored_indent_levels = true;
+        };
+        lsp_trouble = true;
+        mini = true;
+        native_lsp.enabled = true;
+        navic.enabled = true;
+        nvimtree = true;
+        overseer = true;
+        telescope = true;
+        treesitter = true;
+        treesitter_context = true;
+        ts_rainbow2 = true;
+      };
+      styles = {
+        booleans = ["bold" "italic"];
+        conditionals = ["bold"];
+        functions = ["bold"];
+        keywords = ["italic"];
+        loops = ["bold"];
+        operators = ["bold"];
+        properties = ["italic"];
       };
     };
   };


### PR DESCRIPTION
The `colorOverrides` had the wrong type (`attrsOf str` instead of `attrsOf (attrsOf str)`).
I also added a test for non-regression.

Fixes #478 